### PR TITLE
removing warnings for libswamigui library

### DIFF
--- a/src/swamigui/SwamiguiCanvasMod.c
+++ b/src/swamigui/SwamiguiCanvasMod.c
@@ -277,12 +277,12 @@ swamigui_canvas_mod_handle_event (SwamiguiCanvasMod *mod, GdkEvent *event)
 
     mod->snap_active = TRUE;
 
-    mod->xsnap = btn_event->x;
-    mod->cur_xsnap = btn_event->x;
+    mod->xsnap = (int)btn_event->x;
+    mod->cur_xsnap = (int)btn_event->x;
     mod->cur_xchange = TRUE;
 
-    mod->ysnap = btn_event->y;
-    mod->cur_ysnap = btn_event->y;
+    mod->ysnap = (int)btn_event->y;
+    mod->cur_ysnap = (int)btn_event->y;
     mod->cur_ychange = TRUE;
 
     /* add a timeout callback for zoom/scroll if not already added */
@@ -307,13 +307,13 @@ swamigui_canvas_mod_handle_event (SwamiguiCanvasMod *mod, GdkEvent *event)
 
     if (mod->cur_xsnap != motion_event->x)
     {
-      mod->cur_xsnap = motion_event->x;
+      mod->cur_xsnap = (int)motion_event->x;
       mod->cur_xchange = TRUE;
     }
 
     if (mod->cur_ysnap != motion_event->y)
     {
-      mod->cur_ysnap = motion_event->y;
+      mod->cur_ysnap = (int)motion_event->y;
       mod->cur_ychange = TRUE;
     }
     break;
@@ -362,8 +362,8 @@ swamigui_canvas_mod_handle_event (SwamiguiCanvasMod *mod, GdkEvent *event)
     {
       mod->last_wheel_dir = scroll_event->direction;
       mod->wheel_time = mod->one_wheel_time;
-      mod->xwheel = scroll_event->x;
-      mod->ywheel = scroll_event->y;
+      mod->xwheel = (int)scroll_event->x;
+      mod->ywheel = (int)scroll_event->y;
 
       if (!mod->timeout_handler)
       {
@@ -440,6 +440,7 @@ swamigui_canvas_mod_timeout (gpointer data)
   double val, inp, inpy;
   double xpos, ypos;
   guint actions;
+  int wheel_timeout = mod->wheel_timeout;
 
   /* get current keyboard modifier state and resulting actions */
   gdk_display_get_pointer (gdk_display_get_default (), NULL, NULL, NULL, &state);
@@ -453,8 +454,8 @@ swamigui_canvas_mod_timeout (gpointer data)
   /* mouse wheel operation is active */
   if (mod->last_wheel_dir != WHEEL_INACTIVE)
   {
-    inp = mod->wheel_timeout - mod->wheel_time;
-    inp = CLAMP (inp, 0.0, mod->wheel_timeout);
+    inp = wheel_timeout - mod->wheel_time;
+    inp = CLAMP (inp, 0.0, wheel_timeout);
 
     /* calculate the last wheel event time in milliseconds, unfortunately I
      * don't think we can get the current GDK event time, so we have to use
@@ -470,7 +471,7 @@ swamigui_canvas_mod_timeout (gpointer data)
 		       - curtime.tv_usec + 500) / 1000;
 
     /* At end of wheel activity timeout? */
-    if (lastwheel >= mod->wheel_timeout)
+    if (lastwheel >= wheel_timeout)
     {
       mod->last_wheel_dir = WHEEL_INACTIVE;
 
@@ -481,8 +482,8 @@ swamigui_canvas_mod_timeout (gpointer data)
     }
 
     /* wheel timeout taper multiplier (1.0 to 0.0) */
-    wheeltaper = 1.0 - (mod->wheel_timeout - lastwheel)
-      / (double)(mod->wheel_timeout);
+    wheeltaper = 1.0 - (wheel_timeout - lastwheel)
+      / (double)(wheel_timeout);
 
     if (actions & SWAMIGUI_CANVAS_MOD_ZOOM_X)
     {

--- a/src/swamigui/SwamiguiControlMidiKey.c
+++ b/src/swamigui/SwamiguiControlMidiKey.c
@@ -504,7 +504,7 @@ swamigui_control_midi_key_set_lower (SwamiguiControlMidiKey *keyctrl,
 				    const guint *keys, guint count)
 {
   MidiKey midikey;
-  int i;
+  guint i;
 
   g_return_if_fail (SWAMIGUI_IS_CONTROL_MIDI_KEY (keyctrl));
   g_return_if_fail (keys != NULL || count == 0);
@@ -534,7 +534,7 @@ swamigui_control_midi_key_set_upper (SwamiguiControlMidiKey *keyctrl,
 				    const guint *keys, guint count)
 {
   MidiKey midikey;
-  int i;
+  guint i;
 
   g_return_if_fail (SWAMIGUI_IS_CONTROL_MIDI_KEY (keyctrl));
   g_return_if_fail (keys != NULL || count == 0);

--- a/src/swamigui/SwamiguiControl_widgets.c
+++ b/src/swamigui/SwamiguiControl_widgets.c
@@ -1004,7 +1004,7 @@ combo_box_enum_control_handler (GObject *widget, GType value_type, GParamSpec *p
   GtkListStore *store;
   GtkTreeIter iter;
   char *s;
-  int i;
+  guint i;
 
   g_return_val_if_fail (G_TYPE_FUNDAMENTAL (value_type) == G_TYPE_ENUM, NULL);
 
@@ -1069,7 +1069,7 @@ combo_box_enum_control_get_func (SwamiControl *control, GValue *value)
   GEnumClass *enumklass;
   GParamSpec *pspec;
   gpointer data;
-  int active;
+  int active,n_values;
 
   SWAMI_LOCK_READ (control);
   data = SWAMI_CONTROL_FUNC_DATA (control);
@@ -1081,8 +1081,8 @@ combo_box_enum_control_get_func (SwamiControl *control, GValue *value)
   {
     enumklass = g_type_class_ref (G_PARAM_SPEC_TYPE (pspec));	/* ++ ref enum class */
     active = gtk_combo_box_get_active (combo);
-
-    if (active != -1 && active < enumklass->n_values)
+	n_values = enumklass->n_values;
+    if (active != -1 && active < n_values)
       g_value_set_enum (value, enumklass->values[active].value);
 
     g_type_class_unref (enumklass);		/* -- unref enum class */
@@ -1101,7 +1101,8 @@ combo_box_enum_control_set_func (SwamiControl *control, SwamiControlEvent *event
   GEnumClass *enumklass;
   GParamSpec *pspec;
   gpointer data;
-  int pos, val;
+  int val;
+  guint pos;
   GType type;
 
   /* minimize lock time - ref the combo box */
@@ -1145,7 +1146,7 @@ combo_box_enum_control_changed (GtkComboBox *combo, gpointer user_data)
   GParamSpec *pspec;
   GValue value = { 0 };
   GType type;
-  int active;
+  guint active;
 
   pspec = swami_control_get_spec (control);	/* ++ ref param spec */
 
@@ -1154,7 +1155,6 @@ combo_box_enum_control_changed (GtkComboBox *combo, gpointer user_data)
 
   enumklass = g_type_class_ref (type);	/* ++ ref enum class */
   active = gtk_combo_box_get_active (combo);
-
   /* transmit the combo box change */
   if (active < enumklass->n_values)
   {

--- a/src/swamigui/SwamiguiItemMenu.c
+++ b/src/swamigui/SwamiguiItemMenu.c
@@ -274,10 +274,11 @@ swamigui_item_menu_add (SwamiguiItemMenu *menu,
 			const SwamiguiItemMenuInfo *info, const char *action_id)
 {
   GtkWidget *mitem;
-  guint key, mods;
+  guint key;
+  GdkModifierType mods;
   char *accel_path;
   GList *list, *p;
-  int order;
+  guint order;
   int index;
 
   g_return_val_if_fail (SWAMIGUI_IS_ITEM_MENU (menu), NULL);

--- a/src/swamigui/SwamiguiLoopFinder.c
+++ b/src/swamigui/SwamiguiLoopFinder.c
@@ -438,7 +438,7 @@ swamigui_loop_finder_thread_monitor (gpointer user_data)
   guint match_count;
   guint exectime;
   char *s;
-  int i;
+  guint i;
 
   /* read progress float */
   g_object_get (finder->loop_finder,
@@ -483,7 +483,7 @@ swamigui_loop_finder_thread_monitor (gpointer user_data)
     {
       gtk_list_store_append (finder->store, &iter);
 
-      quality = 100.0 - (matches[i].quality - maxq) / diffq * 100.0;
+      quality = (float)(100.0 - (matches[i].quality - maxq) / diffq * 100.0);
 
       gtk_list_store_set (finder->store, &iter,
 		  SIZE_COLUMN, matches[i].end - matches[i].start,

--- a/src/swamigui/SwamiguiNoteSelector.c
+++ b/src/swamigui/SwamiguiNoteSelector.c
@@ -76,7 +76,7 @@ swamigui_note_selector_output (GtkSpinButton *spinbutton)
   int note;
 
   adj = gtk_spin_button_get_adjustment (spinbutton);
-  note = adj->value;
+  note = (int)adj->value;
 
   if (note >= 0 && note <= 127)
   {

--- a/src/swamigui/SwamiguiPanel.c
+++ b/src/swamigui/SwamiguiPanel.c
@@ -164,7 +164,7 @@ swamigui_panel_get_types_in_selection (IpatchList *selection)
   GArray *typearray;
   GType type;
   GList *p;
-  int i;
+  guint i;
 
   typearray = g_array_new (TRUE, FALSE, sizeof (GType));	/* ++ alloc */
 

--- a/src/swamigui/SwamiguiPanelSelector.c
+++ b/src/swamigui/SwamiguiPanelSelector.c
@@ -283,7 +283,7 @@ swamigui_panel_selector_real_set_selection (SwamiguiPanelSelector *selector,
   PanelInfo *info;
   GList *children;
   GList *p;
-  int i;
+  guint i;
 
   g_return_val_if_fail (SWAMIGUI_IS_PANEL_SELECTOR (selector), FALSE);
 

--- a/src/swamigui/SwamiguiPiano.c
+++ b/src/swamigui/SwamiguiPiano.c
@@ -1066,7 +1066,7 @@ swamigui_piano_pos_to_note (SwamiguiPiano *piano, double x, double y,
     return (-1);
 
   /* calculate note */
-  note = x / piano->key_width;
+  note = (int)(x / piano->key_width);
 
   if (note >= piano->key_count) note = piano->key_count - 1;
   mod = note % 12;
@@ -1093,16 +1093,16 @@ swamigui_piano_pos_to_note (SwamiguiPiano *piano, double x, double y,
 	  if (y < piano->black_vel_ofs) *velocity = 1;
 	  else if (y > piano->black_vel_ofs + piano->black_vel_range)
 	    *velocity = 127;
-	  else *velocity = 1.0 + (y - piano->black_vel_ofs)
-		 / (piano->black_vel_range) * 126.0 + 0.5;
+	  else *velocity = (int)(1.0 + (y - piano->black_vel_ofs)
+		 / (piano->black_vel_range) * 126.0 + 0.5);
 	}
       else			/* white key */
 	{
 	  if (y < piano->white_vel_ofs) *velocity = 1;
 	  else if (y > piano->white_vel_ofs + piano->white_vel_range)
 	    *velocity = 127;
-	  else *velocity = 1.0 + (y - piano->white_vel_ofs)
-		 / (piano->white_vel_range) * 126.0 + 0.5;
+	  else *velocity = (int)(1.0 + (y - piano->white_vel_ofs)
+		 / (piano->white_vel_range) * 126.0 + 0.5);
 	}
     }
 

--- a/src/swamigui/SwamiguiRoot.c
+++ b/src/swamigui/SwamiguiRoot.c
@@ -1764,8 +1764,8 @@ category_changed_cb (GtkComboBox *combo, gpointer user_data)
   GtkTreeModel *model;
   GtkTreeIter iter;
   GtkTreePath *path;
-  gint *pinds, d;
-  guint old_cat, new_cat, i;
+  gint *pinds;
+  guint old_cat, new_cat, i, d;
 
   inst = g_object_get_data (G_OBJECT (combo), "controlled-object");
   g_return_if_fail (IPATCH_IS_SLI_INST (inst));

--- a/src/swamigui/SwamiguiSpectrumCanvas.c
+++ b/src/swamigui/SwamiguiSpectrumCanvas.c
@@ -448,10 +448,10 @@ swamigui_spectrum_canvas_draw (GnomeCanvasItem *item, GdkDrawable *drawable,
   yofs = y - canvas->y;		/* y co-ordinate relative to spectrum pos */
 
   /* calculate start index */
-  start = canvas->start + xofs * canvas->zoom + 0.5;
+  start = (int)(canvas->start + xofs * canvas->zoom + 0.5);
 
   /* calculate end index */
-  end = canvas->start + (xofs + width) * canvas->zoom + 0.5;
+  end = (int)(canvas->start + (xofs + width) * canvas->zoom + 0.5);
 
   /* no spectrum in area? */
   if (start >= size || end < 0) return;
@@ -479,7 +479,7 @@ swamigui_spectrum_canvas_draw (GnomeCanvasItem *item, GdkDrawable *drawable,
       else segments = static_segments;
 
       max = -G_MAXDOUBLE;
-      next_index = canvas->start + (xofs + 1) * canvas->zoom + 0.5;
+      next_index = (int)(canvas->start + (xofs + 1) * canvas->zoom + 0.5);
 
       /* draw maximum lines */
       for (xpos = 0, index = start; xpos < width; xpos++)
@@ -492,19 +492,19 @@ swamigui_spectrum_canvas_draw (GnomeCanvasItem *item, GdkDrawable *drawable,
 
 	  segments[xpos].x1 = xpos;
 	  segments[xpos].x2 = xpos;
-	  segments[xpos].y1 = height_1_ofs - max * ampl_mul;
+	  segments[xpos].y1 = (gint)(height_1_ofs - max * ampl_mul);
 	  segments[xpos].y2 = height_1_ofs;
 
 	  if (index >= size) break;
 
-	  next_index = canvas->start + (xofs + xpos + 2) * canvas->zoom + 0.5;
+	  next_index = (int)(canvas->start + (xofs + xpos + 2) * canvas->zoom + 0.5);
 	  max = -G_MAXDOUBLE;
 	}
 
       gdk_draw_segments (drawable, canvas->max_gc, segments, xpos);
 
       min = G_MAXDOUBLE;
-      next_index = canvas->start + (xofs + 1) * canvas->zoom + 0.5;
+      next_index = (int)(canvas->start + (xofs + 1) * canvas->zoom + 0.5);
 
       /* draw minimum lines */
       for (xpos = 0, index = start; xpos < width; xpos++)
@@ -517,12 +517,12 @@ swamigui_spectrum_canvas_draw (GnomeCanvasItem *item, GdkDrawable *drawable,
 
 	  segments[xpos].x1 = xpos;
 	  segments[xpos].x2 = xpos;
-	  segments[xpos].y1 = height_1_ofs - min * ampl_mul;
+	  segments[xpos].y1 = (gint)(height_1_ofs - min * ampl_mul);
 	  segments[xpos].y2 = height_1_ofs;
 
 	  if (index >= size) break;
 
-	  next_index = canvas->start + (xofs + xpos + 2) * canvas->zoom + 0.5;
+	  next_index = (int)(canvas->start + (xofs + xpos + 2) * canvas->zoom + 0.5);
 	  min = G_MAXDOUBLE;
 	}
 
@@ -538,17 +538,17 @@ swamigui_spectrum_canvas_draw (GnomeCanvasItem *item, GdkDrawable *drawable,
       if (start > 0) start--;	/* draw previous bar for overlap */
 
       /* first xpos co-ordinate */
-      xpos = (start - (int)canvas->start) / canvas->zoom - xofs + 0.5;
+      xpos = (int)((start - (int)canvas->start) / canvas->zoom - xofs + 0.5);
 
       for (index = start; index <= end; index++)
 	{
-	  ypos = height_1_ofs - canvas->spectrum[index] * ampl_mul;
+	  ypos = (int)(height_1_ofs - canvas->spectrum[index] * ampl_mul);
 	  val = (index - canvas->start + 1) / canvas->zoom - xofs + 0.5;
 
 	  gdk_draw_rectangle (drawable, canvas->bar_gc, TRUE,
-			      xpos, ypos, val - xpos + 1,
+			      xpos, ypos, (gint)(val - xpos + 1),
 			      height_1_ofs - ypos + 1);
-	  xpos = val;
+	  xpos = (int)val;
 	}
     }
 }
@@ -595,7 +595,7 @@ swamigui_spectrum_canvas_cb_adjustment_value_changed (GtkAdjustment *adj,
 
   canvas->update_adj = FALSE;	/* disable adjustment updates to stop
 				   adjustment loop */
-  start = adj->value;
+  start = (guint)adj->value;
   g_object_set (canvas, "start", start, NULL);
 
   canvas->update_adj = TRUE;	/* re-enable adjustment updates */
@@ -679,13 +679,14 @@ int
 swamigui_spectrum_canvas_pos_to_spectrum (SwamiguiSpectrumCanvas *canvas,
 					  int xpos)
 {
-  int index;
+  int index, spectrum_size;
 
   g_return_val_if_fail (SWAMIGUI_IS_SPECTRUM_CANVAS (canvas), -1);
 
-  index = canvas->start + canvas->zoom * xpos;
+  index = (int)(canvas->start + canvas->zoom * xpos);
+  spectrum_size = canvas->spectrum_size;
 
-  if (index < 0 || index > canvas->spectrum_size)
+  if (index < 0 || index > spectrum_size)
     return (-1);
 
   return (index);
@@ -704,11 +705,12 @@ int
 swamigui_spectrum_canvas_spectrum_to_pos (SwamiguiSpectrumCanvas *canvas,
 					  int index)
 {
-  int xpos;
+  int xpos, start;
 
   g_return_val_if_fail (SWAMIGUI_IS_SPECTRUM_CANVAS (canvas), -1);
+  start = canvas->start;
 
-  if (index < canvas->start) return -1;	/* index before view start? */
-  xpos = (index - canvas->start) / canvas->zoom + 0.5;
+  if (index < start) return -1;	/* index before view start? */
+  xpos = (int)((index - start) / canvas->zoom + 0.5);
   return (xpos < canvas->width) ? xpos : -1; /* return if not after view end */
 }

--- a/src/swamigui/SwamiguiSplits.c
+++ b/src/swamigui/SwamiguiSplits.c
@@ -510,7 +510,7 @@ swamigui_splits_cb_low_canvas_event (GnomeCanvasItem *item, GdkEvent *event,
       if (!(bevent->button >= 1 && bevent->button <= 3) || bevent->y < 0.0)
 	break;
 
-      p = swamigui_splits_get_split_at_pos (splits, bevent->x, bevent->y, &index);
+      p = swamigui_splits_get_split_at_pos (splits, (int)bevent->x, (int)bevent->y, &index);
       if (!p) return (FALSE);	/* no split found? */
 
       selsplit = (SwamiguiSplitsEntry *)(p->data);
@@ -675,7 +675,7 @@ swamigui_splits_cb_low_canvas_event (GnomeCanvasItem *item, GdkEvent *event,
       mevent = (GdkEventMotion *)event;
       if (splits->active_drag == ACTIVE_NONE)
 	{
-	  p = swamigui_splits_get_split_at_pos (splits, mevent->x, mevent->y, NULL);
+	  p = swamigui_splits_get_split_at_pos (splits, (int)mevent->x, (int)mevent->y, NULL);
 	  if (p)
 	    {
 	      entry = (SwamiguiSplitsEntry *)(p->data);
@@ -743,7 +743,7 @@ swamigui_splits_cb_low_canvas_event (GnomeCanvasItem *item, GdkEvent *event,
 
 	  if (splits->active_drag != ACTIVE_MOVE_RANGES && entry->rootnote)
 	  {
-	    if ((int)(entry->rootnote_val) + noteofs < 0) noteofs = -entry->rootnote_val;
+	    if ((int)(entry->rootnote_val) + noteofs < 0) noteofs = -(int)entry->rootnote_val;
 	    if ((int)(entry->rootnote_val) + noteofs > 127) noteofs = 127 - entry->rootnote_val;
 	  }
 	}
@@ -1402,15 +1402,17 @@ swamigui_splits_insert (SwamiguiSplits *splits, GObject *item, int index)
 {
   SwamiguiSplitsEntry *entry;
   GList *p;
+  int entry_count;
 
   g_return_val_if_fail (SWAMIGUI_IS_SPLITS (splits), NULL);
   g_return_val_if_fail (IPATCH_IS_ITEM (item), NULL);
 
   entry = swamigui_splits_create_entry (splits, item);
+  entry_count = splits->entry_count;
 
-  if (index < 0 || index >= splits->entry_count)	/* Append? */
+  if (index < 0 || index >= entry_count)	/* Append? */
   {
-    index = splits->entry_count;
+    index = entry_count;
     splits->entry_list = g_list_append (splits->entry_list, entry);
     p = NULL;
   }
@@ -2055,9 +2057,9 @@ swamigui_splits_create_velocity_gradient (void)
 
   for (i = 0; i < 128 * 3;)
     {
-      linebuf[i++] = rval + 0.5;
-      linebuf[i++] = gval + 0.5;
-      linebuf[i++] = bval + 0.5;
+      linebuf[i++] = (guchar)(rval + 0.5);
+      linebuf[i++] = (guchar)(gval + 0.5);
+      linebuf[i++] = (guchar)(bval + 0.5);
 
       rval += rinc;
       gval += ginc;

--- a/src/swamigui/SwamiguiTree.c
+++ b/src/swamigui/SwamiguiTree.c
@@ -730,8 +730,8 @@ swamigui_tree_cb_button_press (GtkWidget *widg, GdkEventButton *event,
   if (!tree->seltree) return (FALSE);	/* Shouldn't happen, but.. */
   if (event->button != 3) return (FALSE);
 
-  x = event->x;		/* x and y coordinates are of type double */
-  y = event->y;		/* convert to integer */
+  x = (int)event->x;		/* x and y coordinates are of type double */
+  y = (int)event->y;		/* convert to integer */
 
   /* get the tree path at the given mouse cursor position
    * ++ alloc path */

--- a/src/swamigui/SwamiguiTreeStorePatch.c
+++ b/src/swamigui/SwamiguiTreeStorePatch.c
@@ -212,7 +212,7 @@ swamigui_tree_store_patch_real_item_add (
   GArray *title_sort_array = NULL;
   GHashTable *prev_child_hash = NULL;
   GList *p;
-  int i;
+  guint i;
 
   /* ++ ref parent */
   parent = (GObject *)ipatch_item_get_parent (IPATCH_ITEM (item));

--- a/src/swamigui/patch_funcs.c
+++ b/src/swamigui/patch_funcs.c
@@ -696,7 +696,8 @@ swamigui_export_samples (IpatchList *samples)
   gboolean multi;
   GtkTreeIter iter;
   IpatchSample *sample = NULL;
-  int i, sel, def_index = 0;
+  int sel, def_index = 0;
+  guint i;
   GList *p;
 
   g_return_if_fail (IPATCH_IS_LIST (samples));


### PR DESCRIPTION
- removing warnings signed/unsigned comparison.
- explicit cast on conversion (e.g double->int).
- SwamiguiItemMenu.c: change type of mods from guint to GdkModifierType.