### PR TITLE
Fluidsynth plugin adaptation for Windows

### DIFF
--- a/src/plugins/CMakeLists.txt
+++ b/src/plugins/CMakeLists.txt
@@ -33,11 +33,13 @@ link_directories ( ${GOBJECT_LIBDIR} ${GOBJECT_LIBRARY_DIRS}
 )
 
 set (DEFINITION_FILE_FLUIDSYNTH_PLUGIN "")
+set (DEFINITION_FILE_FLUIDSYNTH_GUI "")
 # Options for WINDOWS only
 if( WIN32 )
     if (BUILD_SHARED_LIBS)
         # adding a module definition file for shared libs will export symbols and produce import library
         set (DEFINITION_FILE_FLUIDSYNTH_PLUGIN fluidsynth_plugin.def)
+        set (DEFINITION_FILE_FLUIDSYNTH_GUI fluidsynth_gui.def)
     endif(BUILD_SHARED_LIBS)
 endif( WIN32 )
 
@@ -51,7 +53,7 @@ link_directories ( ${GUI_LIBDIR} ${GUI_LIBRARY_DIRS} ${LIBINSTPATCH_LIBDIR}
     ${LIBINSTPATCH_LIBRARY_DIRS} ${FLUIDSYNTH_LIBDIR} ${FLUIDSYNTH_LIBRARY_DIRS}
 )
 
-add_library ( fluidsynth_gui MODULE fluidsynth_gui.c )
+add_library ( fluidsynth_gui MODULE fluidsynth_gui.c ${DEFINITION_FILE_FLUIDSYNTH_GUI})
 
 target_link_libraries ( fluidsynth_gui libswami libswamigui ${GUI_LIBRARIES}
     ${LIBINSTPATCH_LIBRARIES} ${FLUIDSYNTH_LIBRARIES}

--- a/src/plugins/CMakeLists.txt
+++ b/src/plugins/CMakeLists.txt
@@ -32,7 +32,16 @@ link_directories ( ${GOBJECT_LIBDIR} ${GOBJECT_LIBRARY_DIRS}
     ${FLUIDSYNTH_LIBRARY_DIRS}
 )
 
-add_library ( fluidsynth_plugin MODULE fluidsynth.c )
+set (DEFINITION_FILE_FLUIDSYNTH_PLUGIN "")
+# Options for WINDOWS only
+if( WIN32 )
+    if (BUILD_SHARED_LIBS)
+        # adding a module definition file for shared libs will export symbols and produce import library
+        set (DEFINITION_FILE_FLUIDSYNTH_PLUGIN fluidsynth_plugin.def)
+    endif(BUILD_SHARED_LIBS)
+endif( WIN32 )
+
+add_library ( fluidsynth_plugin MODULE fluidsynth.c ${DEFINITION_FILE_FLUIDSYNTH_PLUGIN})
 
 target_link_libraries ( fluidsynth_plugin libswami libswamigui ${GOBJECT_LIBRARIES}
     ${LIBINSTPATCH_LIBRARIES} ${FLUIDSYNTH_LIBRARIES}

--- a/src/plugins/fluidsynth.c
+++ b/src/plugins/fluidsynth.c
@@ -419,6 +419,9 @@ static gboolean
 plugin_fluidsynth_save_xml (SwamiPlugin *plugin, GNode *xmlnode, GError **err)
 {
   WavetblFluidSynth *wavetbl;
+  
+  /* get swamigui_root from swamigui library */
+  SwamiguiRoot * swamigui_root = swamigui_get_swamigui_root ();
 
   if (!swamigui_root || !swamigui_root->wavetbl
       || !WAVETBL_IS_FLUIDSYNTH (swamigui_root->wavetbl))
@@ -438,6 +441,8 @@ plugin_fluidsynth_load_xml (SwamiPlugin *plugin, GNode *xmlnode, GError **err)
 {
   WavetblFluidSynth *wavetbl;
 
+  /* get swamigui_root from swamigui library */
+  SwamiguiRoot * swamigui_root = swamigui_get_swamigui_root ();
   if (!swamigui_root || !swamigui_root->wavetbl
       || !WAVETBL_IS_FLUIDSYNTH (swamigui_root->wavetbl))
   {

--- a/src/plugins/fluidsynth.c
+++ b/src/plugins/fluidsynth.c
@@ -290,7 +290,7 @@ static GType chorus_waveform_type = 0;
 static GObjectClass *wavetbl_parent_class = NULL;
 
 /* last dynamic property ID (incremented for each dynamically installed prop) */
-static int last_property_id = FIRST_DYNAMIC_PROP;
+static guint last_property_id = FIRST_DYNAMIC_PROP;
 
 /* stores all dynamic FluidSynth setting names for mapping between property
    ID and FluidSynth setting */

--- a/src/plugins/fluidsynth.c
+++ b/src/plugins/fluidsynth.c
@@ -2014,7 +2014,11 @@ cache_instrument_noteon (WavetblFluidSynth *wavetbl, IpatchItem *item,
 	if (IPATCH_SF2_GEN_ARRAY_TEST_FLAG (gen_array, i))
 	  fluid_voice_gen_set (flvoice, i, (float)(gen_array->values[i].sword));
 
+	  /* set modulators in fvoice internal list */
+	  /* Note: here modulators are assumed non-linked modulators */
       wumod = g_alloca(fluid_mod_sizeof());
+	  /* clear  fields is more safe.( in particular next field ) */
+	  memset(wumod,0,fluid_mod_sizeof());
       p = voice->mod_list;
       while (p)
 	{

--- a/src/plugins/fluidsynth.def
+++ b/src/plugins/fluidsynth.def
@@ -1,3 +1,0 @@
-LIBRARY fluidsynth.dll
-EXPORTS
-swami_plugin_info DATA

--- a/src/plugins/fluidsynth_gui.c
+++ b/src/plugins/fluidsynth_gui.c
@@ -101,6 +101,9 @@ fluid_synth_pref_handler (void)
   GtkCellRenderer *cell;
   char **options, **optionp;
 
+  /* get swamigui_root from swamigui library */
+  SwamiguiRoot * swamigui_root = swamigui_get_swamigui_root ();
+
   fluid_widg = swamigui_util_glade_create ("FluidSynthPrefs");
 
   if (swamigui_root->wavetbl)
@@ -180,6 +183,9 @@ fluid_synth_gui_audio_driver_changed (GtkComboBox *combo, gpointer user_data)
   char *driver, *widgname;
   const char **sptr;
 
+  /* get swamigui_root from swamigui library */
+  SwamiguiRoot * swamigui_root = swamigui_get_swamigui_root ();
+
   driver = gtk_combo_box_get_active_text (combo);	/* ++ alloc */
 
   vbox = swamigui_util_glade_lookup (fluid_widg, "VBoxAudioDriver");
@@ -215,6 +221,9 @@ fluid_synth_gui_midi_driver_changed (GtkComboBox *combo, gpointer user_data)
   GtkWidget *vbox;
   char *driver, *widgname;
   const char **sptr;
+
+  /* get swamigui_root from swamigui library */
+  SwamiguiRoot * swamigui_root = swamigui_get_swamigui_root ();
 
   driver = gtk_combo_box_get_active_text (combo);	/* ++ alloc */
 
@@ -280,6 +289,9 @@ fluid_synth_gui_control_init (FluidSynthGuiControl *fsctrl)
   GtkWidget *widg;
   GType type;
   int i;
+
+  /* get swamigui_root from swamigui library */
+  SwamiguiRoot * swamigui_root = swamigui_get_swamigui_root ();
 
   fsctrl->ctrl_widg = swamigui_util_glade_create ("FluidSynth");
   gtk_widget_show (fsctrl->ctrl_widg);

--- a/src/plugins/fluidsynth_gui.def
+++ b/src/plugins/fluidsynth_gui.def
@@ -1,0 +1,3 @@
+LIBRARY
+EXPORTS
+swami_plugin_info

--- a/src/plugins/fluidsynth_plugin.def
+++ b/src/plugins/fluidsynth_plugin.def
@@ -1,0 +1,3 @@
+LIBRARY
+EXPORTS
+swami_plugin_info


### PR DESCRIPTION
This PR allows to build `fluidsynth plugin` on Windows with 0 errors and 0 warnings.
It could be merged.
