### PR TITLE
Avoid the user to be forced to click twice

### DIFF
--- a/src/swamigui/SwamiguiModEdit.c
+++ b/src/swamigui/SwamiguiModEdit.c
@@ -357,10 +357,26 @@ swamigui_mod_edit_get_type (void)
   return (obj_type);
 }
 
+/* Override mouse button event:
+   To avoid lose of focus in pannels selector (GtkNoteBook tabs selector).
+   Otherwise,the user would be forced to clic two times when he want to select
+   another pannel.
+*/
+static gboolean swamigui_mod_edit_press_button (GtkWidget *widget,
+                                                GdkEventButton *event)
+{
+    /*  mouse click button propagation is ignored */
+    return TRUE;
+}
+
 static void
 swamigui_mod_edit_class_init (SwamiguiModEditClass *klass)
 {
   GObjectClass *obj_class = G_OBJECT_CLASS (klass);
+
+  /* Override mouse button event */
+  GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
+  widget_class->button_press_event = swamigui_mod_edit_press_button ;
 
   parent_class = g_type_class_peek_parent (klass);
 

--- a/src/swamigui/SwamiguiPanelSF2Gen.c
+++ b/src/swamigui/SwamiguiPanelSF2Gen.c
@@ -89,10 +89,26 @@ G_DEFINE_ABSTRACT_TYPE_WITH_CODE (SwamiguiPanelSF2Gen, swamigui_panel_sf2_gen,
 		    G_IMPLEMENT_INTERFACE (SWAMIGUI_TYPE_PANEL,
 					   swamigui_panel_sf2_gen_panel_iface_init));
 
+/* Override mouse button event:
+   To avoid lose of focus in pannels selector (GtkNoteBook tabs selector).
+   Otherwise,the user would be forced to clic two times when he want to select
+   another pannel.
+*/
+static gboolean swamigui_panel_sf2_gen_press_button (GtkWidget *widget,
+                                                     GdkEventButton *event)
+{
+    /*  mouse click button propagation is ignored */
+    return TRUE;
+}
+
 static void
 swamigui_panel_sf2_gen_class_init (SwamiguiPanelSF2GenClass *klass)
 {
   GObjectClass *obj_class = G_OBJECT_CLASS (klass);
+
+  /* Override mouse button event */
+  GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
+  widget_class->button_press_event = swamigui_panel_sf2_gen_press_button ;
 
   obj_class->set_property = swamigui_panel_sf2_gen_set_property;
   obj_class->get_property = swamigui_panel_sf2_gen_get_property;

--- a/src/swamigui/SwamiguiProp.c
+++ b/src/swamigui/SwamiguiProp.c
@@ -168,10 +168,26 @@ swamigui_prop_get_type (void)
   return (obj_type);
 }
 
+/* Override mouse button event:
+   To avoid lose of focus in pannels selector (GtkNoteBook tabs selector).
+   Otherwise,the user would be forced to clic two times when he want to select
+   another pannel.
+*/
+static gboolean swamigui_prop_press_button (GtkWidget *widget,
+                                                     GdkEventButton *event)
+{
+    /*  mouse click button propagation is ignored */
+    return TRUE;
+}
+
 static void
 swamigui_prop_class_init (SwamiguiPropClass *klass)
 {
   GObjectClass *obj_class = G_OBJECT_CLASS (klass);
+
+  /* Override mouse button event */
+  GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
+  widget_class->button_press_event = swamigui_prop_press_button ;
 
   parent_class = g_type_class_peek_parent (klass);
 


### PR DESCRIPTION
This fix avoid the user to be forced to clic two time when he want to select another panel.
The issue occurs when the user does the following actions:
1) select one panel (clic on notebook tab).
2) click inside the panel (not on child widget).
3) select another panel (clic on another notebook tab).
   To get this other panel selected, the user need to click twice.

Note: Consider this fix as a workaround. May be a better fix would be to set the right property on parent Windows Widget. For now I don't know how to do.