### PR TITLE
Show dialog box centered on top of main window

### DIFF
--- a/src/swamigui/SwamiguiMenu.c
+++ b/src/swamigui/SwamiguiMenu.c
@@ -625,7 +625,7 @@ swamigui_menu_cb_preferences(GtkWidget *mitem, gpointer data)
     {
         pref = swamigui_pref_new();
         /* The dialog is registered and set centered on top of the main window.
-           To get this result the dialog must be hide beforehand, otherwise
+           To get this result the dialog must be hidden beforehand, otherwise
            gtk_window_set_transient_for() will be ignored.
         */
         swamigui_util_register_unique_dialog(pref, "preferences", 0);

--- a/src/swamigui/SwamiguiMenu.c
+++ b/src/swamigui/SwamiguiMenu.c
@@ -621,13 +621,15 @@ swamigui_menu_cb_preferences(GtkWidget *mitem, gpointer data)
 {
     GtkWidget *pref;
 
-    pref = swamigui_util_lookup_unique_dialog("preferences", 0);
-
-    if(!pref)
+    if(!swamigui_util_activate_unique_dialog("preferences", 0))
     {
         pref = swamigui_pref_new();
-        gtk_widget_show(pref);
+        /* The dialog is registered and set centered on top of the main window.
+           To get this result the dialog must be hide beforehand, otherwise
+           gtk_window_set_transient_for() will be ignored.
+        */
         swamigui_util_register_unique_dialog(pref, "preferences", 0);
+        gtk_widget_show(pref);
     }
 }
 

--- a/src/swamigui/splash.c
+++ b/src/swamigui/splash.c
@@ -28,6 +28,8 @@
 #include <png.h>
 #include "util.h"
 
+#include "SwamiGuiRoot.h"
+
 static void cb_win_destroy(GtkWidget *win);
 static gboolean cb_button_press(GtkWidget *widg, GdkEventButton *ev);
 
@@ -69,7 +71,8 @@ swamigui_splash_display(guint timeout)
     }
 
     /* splash popup window */
-    splash_win = gtk_window_new(GTK_WINDOW_POPUP);
+    splash_win = gtk_dialog_new();
+    gtk_window_set_decorated ((GtkWindow *)splash_win, FALSE);
     gtk_window_set_type_hint(GTK_WINDOW(splash_win), GDK_WINDOW_TYPE_HINT_SPLASHSCREEN);
     gtk_window_set_resizable(GTK_WINDOW(splash_win), FALSE);
     gtk_signal_connect(GTK_OBJECT(splash_win), "destroy",
@@ -79,10 +82,10 @@ swamigui_splash_display(guint timeout)
     gtk_widget_add_events(splash_win, GDK_BUTTON_PRESS_MASK);
 
     image = gtk_image_new_from_pixbuf(pixbuf);
-    gtk_container_add(GTK_CONTAINER(splash_win), image);
+    gtk_container_add(GTK_CONTAINER(GTK_DIALOG(splash_win)->action_area), image);
     gtk_widget_show(image);
 
-    gtk_window_set_position(GTK_WINDOW(splash_win), GTK_WIN_POS_CENTER);
+    gtk_window_set_transient_for(GTK_WINDOW(splash_win), GTK_WINDOW(swamigui_root->main_window));
     gtk_widget_show(splash_win);
 
     g_object_unref(pixbuf);	/* -- unref pixbuf creator's ref */

--- a/src/swamigui/splash.c
+++ b/src/swamigui/splash.c
@@ -28,7 +28,7 @@
 #include <png.h>
 #include "util.h"
 
-#include "SwamiGuiRoot.h"
+#include "SwamiguiRoot.h"
 
 static void cb_win_destroy(GtkWidget *win);
 static gboolean cb_button_press(GtkWidget *widg, GdkEventButton *ev);

--- a/src/swamigui/swami-2.ui
+++ b/src/swamigui/swami-2.ui
@@ -4,7 +4,7 @@
   <!-- interface-requires swamigui 3.0 -->
   <!-- interface-naming-policy toplevel-contextual -->
   <object class="GtkAboutDialog" id="About">
-    <property name="visible">True</property>
+    <property name="visible">False</property>
     <property name="can_focus">False</property>
     <property name="window_position">center-on-parent</property>
     <property name="type_hint">normal</property>
@@ -4584,7 +4584,7 @@ BALATON Zoltan &lt;balaton@users.sourceforge.net&gt; (Spectralis support, Mac OS
     </child>
   </object>
   <object class="GtkWindow" id="Tips">
-    <property name="visible">True</property>
+    <property name="visible">False</property>
     <property name="can_focus">False</property>
     <property name="title">Swami Tips</property>
     <property name="default_width">340</property>

--- a/src/swamigui/util.c
+++ b/src/swamigui/util.c
@@ -186,10 +186,10 @@ swamigui_util_register_unique_dialog(GtkWidget *dialog, gchar *strkey,
     }
 
     /* We want the dialog set centered on top of the main window. To get
-       this result we need to hide the dialog beforehand, otherwise
-       gtk_window_set_transient_for() will be ignored.
+       this result we need that the dialog be not visible beforehand, otherwise
+       gtk_window_set_transient_for() will be ignored. This is done in swami.ui
+       by setting visible property to false: <property name="visible">False</property>
     */
-    gtk_widget_hide(dialog);
     gtk_window_set_transient_for(GTK_WINDOW(dialog), GTK_WINDOW(swamigui_root->main_window));
 
     /* ensure the dialog will be destroy when the parent will be destroyed */

--- a/src/swamigui/util.c
+++ b/src/swamigui/util.c
@@ -192,6 +192,9 @@ swamigui_util_register_unique_dialog(GtkWidget *dialog, gchar *strkey,
     gtk_widget_hide(dialog);
     gtk_window_set_transient_for(GTK_WINDOW(dialog), GTK_WINDOW(swamigui_root->main_window));
 
+    /* ensure the dialog will be destroy when the parent will be destroyed */
+    gtk_window_set_destroy_with_parent((GtkWindow*)dialog, TRUE);
+
     udkey.dialog = dialog;
     udkey.strkey = strkey;
     udkey.key2 = key2;

--- a/src/swamigui/util.c
+++ b/src/swamigui/util.c
@@ -185,6 +185,11 @@ swamigui_util_register_unique_dialog(GtkWidget *dialog, gchar *strkey,
         return (FALSE);
     }
 
+    /* We want the dialog set centered on top of the main window. To get
+       this result we need to hide the dialog beforehand, otherwise
+       gtk_window_set_transient_for() will be ignored.
+    */
+    gtk_widget_hide(dialog);
     gtk_window_set_transient_for(GTK_WINDOW(dialog), GTK_WINDOW(swamigui_root->main_window));
 
     udkey.dialog = dialog;


### PR DESCRIPTION
On Windows actually dialogs (Preference, Tips, About, Splash) are show far away of swami main window. This PR fix this by setting the dialog in the center of swami window. 
This PR works on Windows.
Because of the difference between host window managers, please, this should be verified on linux too.

- Menu ->Edit-> Preferences should show the dialog centered.
- Idem for Menu ->Help->(Tips,Splash image, About)