### PR TITLE
Start of hunting about missing g_object_unref()

### DIFF
--- a/src/libswami/SwamiControl.c
+++ b/src/libswami/SwamiControl.c
@@ -214,7 +214,12 @@ static void
 swami_control_finalize(GObject *object)
 {
     SwamiControl *control = SWAMI_CONTROL(object);
-    swami_control_disconnect_all(control);
+
+    /* free control queue (if any exist) */
+    if (control->queue)
+    {
+        g_object_unref (control->queue); /* -- unref old queue */
+    }
 
     G_LOCK(control_list);
     control_list = g_list_remove(control_list, object);
@@ -989,7 +994,13 @@ swami_control_get_flags(SwamiControl *control)
  * Set the queue used by a control object. When a control has a queue all
  * receive/set events are sent to the queue. This queue can then be processed
  * at a later time (a GUI thread for example).
- */
+ *
+ * queue is onwned by the control(++ref).
+ * The queue can be removed later by calling the function with NULL for queue
+ * parameter.
+ * Also, when a control is finalized, the queue is removed and finalized
+ * if it isn't owned by another control.
+*/
 void
 swami_control_set_queue(SwamiControl *control, SwamiControlQueue *queue)
 {

--- a/src/libswami/libswami.c
+++ b/src/libswami/libswami.c
@@ -142,7 +142,7 @@ swami_init(void)
 //    start_count_obj("SwamiControl");       // 2 permanent control never finalized
 //    start_count_obj("SwamiControlFunc");   // to be checked
 //    start_count_obj("SwamiControlHub");    // to be checked
-     start_count_obj("SwamiControlProp");  // 1 permanent control never finalize
+//     start_count_obj("SwamiControlProp");  // 1 permanent control never finalize
 //     start_count_obj("SwamiControlMidi");  // to be checked
 //     start_count_obj("SwamiControlValue"); // to be checked
 //     start_count_obj("SwamiControlQueue"); // to be checked

--- a/src/libswami/libswami.c
+++ b/src/libswami/libswami.c
@@ -139,10 +139,10 @@ swami_init(void)
 #if capture_object
 /* Start capture of object (for debugging) (see util.c for details) */
 //------- libswami
-    start_count_obj("SwamiControl");       // 2 permanent control never finalized
+//    start_count_obj("SwamiControl");       // 2 permanent control never finalized
 //    start_count_obj("SwamiControlFunc");   // to be checked
 //    start_count_obj("SwamiControlHub");    // to be checked
-//     start_count_obj("SwamiControlProp");  // 1 permanent control never finalize
+     start_count_obj("SwamiControlProp");  // 1 permanent control never finalize
 //     start_count_obj("SwamiControlMidi");  // to be checked
 //     start_count_obj("SwamiControlValue"); // to be checked
 //     start_count_obj("SwamiControlQueue"); // to be checked

--- a/src/libswami/libswami.c
+++ b/src/libswami/libswami.c
@@ -32,6 +32,7 @@
 #include "builtin_enums.h"
 #include "i18n.h"
 
+
 /* inactive control event expiration interval in milliseconds */
 #define SWAMI_CONTROL_EVENT_EXPIRE_INTERVAL 10000
 
@@ -135,6 +136,24 @@ swami_init(void)
     g_type_class_ref(SWAMI_TYPE_PROP_TREE);
     g_type_class_ref(SWAMI_TYPE_WAVETBL);
 
+#if capture_object
+/* Start capture of object (for debugging) (see util.c for details) */
+//------- libswami
+    start_count_obj("SwamiControl");       // 2 permanent control never finalized
+//    start_count_obj("SwamiControlFunc");   // to be checked
+//    start_count_obj("SwamiControlHub");    // to be checked
+//     start_count_obj("SwamiControlProp");  // 1 permanent control never finalize
+//     start_count_obj("SwamiControlMidi");  // to be checked
+//     start_count_obj("SwamiControlValue"); // to be checked
+//     start_count_obj("SwamiControlQueue"); // to be checked
+//     start_count_obj("SwamiLock");         // to be checked
+//     start_count_obj("SwamiControlMidiDevice"); // abstract type non instantiable
+//     start_count_obj("SwamiPlugin");       // to be checked
+//     start_count_obj("SwamiPropTree");     // to be checked
+//     start_count_obj("SwamiWavetbl");      // abstract type non instantiable
+//     start_count_obj("SwamiRoot");         // to be checked
+//     start_count_obj("SwamiContainer");    // to be checked
+#endif
     _swami_plugin_initialize();	/* initialize plugin system */
 
     /* create IpatchItem title property control */

--- a/src/libswami/libswami.c
+++ b/src/libswami/libswami.c
@@ -142,7 +142,7 @@ swami_init(void)
 //    start_count_obj("SwamiControl");       // 2 permanent control never finalized
 //    start_count_obj("SwamiControlFunc");   // to be checked
 //    start_count_obj("SwamiControlHub");    // to be checked
-//     start_count_obj("SwamiControlProp");  // 1 permanent control never finalize
+     start_count_obj("SwamiControlProp");  // 1 permanent control never finalize
 //     start_count_obj("SwamiControlMidi");  // to be checked
 //     start_count_obj("SwamiControlValue"); // to be checked
 //     start_count_obj("SwamiControlQueue"); // to be checked

--- a/src/libswami/libswami.def
+++ b/src/libswami/libswami.def
@@ -1,6 +1,10 @@
 LIBRARY
 EXPORTS
 
+; capture functions (for debugging)
+start_count_obj
+stop_count_obj
+
 _swami_object_init
 ;_swami_param_init
 

--- a/src/libswami/libswami.h
+++ b/src/libswami/libswami.h
@@ -28,6 +28,12 @@
 #include <libswami/SwamiControl.h>
 #include <libswami/SwamiEvent_ipatch.h>
 
+#define capture_object 1 // for debugging
+#if capture_object
+gboolean start_count_obj(char *type_name);
+gboolean stop_count_obj();
+#endif
+
 /* libswami.c */
 void swami_init(void);
 

--- a/src/libswami/util.c
+++ b/src/libswami/util.c
@@ -30,7 +30,236 @@
 
 static void recurse_types(GType type, GArray *array);
 
+#define capture_object 1 // for debugging
+#if capture_object
+/*----------------------------------------------------------------------------
+ GObject type instance capture system.
+-----------------------------------------------------------------------------*/
+/*
+ Description:
+ This ultra simple interactive system is particularly useful during
+ debugging helping to localize any missing  g_object_unref() call inside the
+ whole application using the GObject library.
 
+ The system allows to focus on a given type of object to track inside a given
+ code section of the application. For example if one want to know if all object
+ of type "SwamiControl" are instancied/finalized, we just need to start  a
+ capture of this type by calling start_count_obj("SwamiControl") at the
+ beginning of the application (after type registration). Then we must call
+ stop_count_obj() at the end of the application. The system displays messages
+ to the stdout console.
+
+ After a capture is started:
+ - The system capture all instances creation of "SwamiControl" object and
+   displays a message on the console:
+       "Start capture of object "SamiControl":
+	   ....
+       "create object SwamiControl=32075784, count=1"
+       "create object SwamiControl=32075999, count=2"
+	   ...
+ - When any instance is finalised the sytem display a message:
+       "finalize object SwamiControl=32075784, count=1"
+
+ Note:
+ - When an instance is created before calling start_capture() and it is
+   finalized during the capture, the message is:
+       "finalize object SwamiControl=30511552 not in capture list"
+
+ When the capture is stopped, the system display all remaining instance not
+ yet finalized during the capture:
+
+   Capture stopped
+     remaining object SwamiControl=51495624
+     remaining object SwamiControl=51495448
+     remaining object SwamiControl=30908200
+     Remaining object count: 3
+     Press "entry" to continue
+
+ In this example the counter "says" that 3 instances are not finalized during
+ the capture.
+-----------------------------------------------------------------------------*/
+
+static GObject* hook_constructor(GType                 type,
+                                 guint                 n_construct_properties,
+                                 GObjectConstructParam *construct_properties);
+static void hook_finalize(GObject *object);
+
+#define CAPTURE_STARTED  0x01 /* capture has been started */
+#define OBJECT_CAPTURED  0x02 /* At leat one object has been captured */
+
+static struct _capture_obj
+{
+    /* constructor */
+    GObject* (*ori_constructor)  (GType                 type,
+                                  guint                 n_construct_properties,
+                                  GObjectConstructParam *construct_properties);
+    /* finalize */
+    void (*ori_finalize) (GObject *object);
+    GObjectClass  *obj_class;        /* class of object */
+    guint8 flags;
+    GType type;       /* type of object under capture */
+    guint count;      /* actual number of object captured */
+    GList *list_obj;  /* the list of object captured */
+}capture_obj;
+
+/* hook callback, called on instance construction */
+static GObject* hook_constructor  (GType                 type,
+                                   guint                 n_construct_properties,
+                                   GObjectConstructParam *construct_properties)
+{
+    /* calling original instance constructor */
+    GObject *object = capture_obj.ori_constructor(type, n_construct_properties,
+                                                  construct_properties);
+
+    if(g_list_find (capture_obj.list_obj, object))
+    {
+        printf("Error, this shouldn't happens\n");
+    }
+	/* memorise the instance of interest in list */
+    if(type == capture_obj.type)
+    {
+        capture_obj.list_obj = g_list_prepend (capture_obj.list_obj, object);
+        capture_obj.count++; /* update count of instance in list */
+        /* just to know that at least one object has been captured */
+        capture_obj.flags |= OBJECT_CAPTURED;
+        printf("Create object %s=%d, count=%d\n", G_OBJECT_TYPE_NAME(object),
+                                                  object, capture_obj.count);
+    }
+    return object; /* return new instance */
+}
+
+/* hook callback, called on instance finalization */
+static void hook_finalize(GObject *object)
+{
+    GType type = G_TYPE_FROM_INSTANCE(object);
+    if(type == capture_obj.type)
+    {
+        /* find and remove object from list*/
+        GList *element = g_list_find (capture_obj.list_obj, object);
+        if(element)
+        {
+            capture_obj.list_obj = g_list_delete_link(capture_obj.list_obj, element);
+            capture_obj.count--;
+            printf("Finalize object %s=%d, count=%d\n", g_type_name(type), object, capture_obj.count);
+        }
+        else
+        {
+            printf("Finalize object %s=%d not in capture list\n", g_type_name(type), object);
+        }
+    }
+
+    /* calling original finalization method */
+    if( capture_obj.ori_finalize)
+    {
+        capture_obj.ori_finalize(object);
+    }
+}
+
+/*
+  start_count_obj(char * name_type)
+  The function start a capture of all creation/destruction instance of the named
+  type of object.
+
+  The type must already registered and derived from G_TYPE_OBJECT, and it must be
+  instantiable, (abstact types are invalid).
+  If a capture is already started, the function fail.
+
+  @type_name: The name of the type object to be captured
+  @return TRUE if a capture is started, FALSE otherwise
+*/
+gboolean start_count_obj(char *type_name)
+{
+    GType type;
+    if(capture_obj.flags != 0)
+    {
+        printf("Cannot start capture because a capture is already started, stop capture first !\n");
+        return FALSE;
+    }
+    /* check if type exist and is valid */
+    type = g_type_from_name (type_name);
+	if(! g_type_is_a(type, G_TYPE_OBJECT))
+    {
+        printf("Cannot start capture of invalid object \"%s\"!\n", type_name);
+        return FALSE;
+    }
+    {
+        GObjectClass  *obj_class;
+        obj_class = (GObjectClass *)g_type_class_peek(type);
+
+        if(obj_class == NULL)
+        {
+            obj_class = (GObjectClass *)g_type_class_ref(type);
+        }
+        capture_obj.obj_class = obj_class;
+        capture_obj.type = type; /* type object of interest */
+        capture_obj.count = 0;   /* reset count */
+        capture_obj.flags = CAPTURE_STARTED;   /*  flags */
+        capture_obj.list_obj = NULL; /* init list */
+
+        /* install hooks in relevent parent class */
+        capture_obj.ori_constructor = obj_class->constructor;
+        obj_class->constructor = hook_constructor;
+
+        capture_obj.ori_finalize = obj_class->finalize;
+        obj_class->finalize = hook_finalize;
+
+        printf("Start capture of object \"%s\":\n", g_type_name(capture_obj.type));
+        return TRUE;
+    }
+}
+
+/*
+ Stop a capture started with start_count_obj(), otherwise the function fail.
+ @return TRUE if a capture is stopped, FALSE otherwise
+*/
+gboolean stop_count_obj()
+{
+    GList *obj;
+
+    if(!(capture_obj.flags & CAPTURE_STARTED))
+    {
+        printf("Cannot stop a capture, start a capture first!\n");
+        return FALSE;
+    }
+
+    printf("Capture of object \"%s\" stopped\n", g_type_name(capture_obj.type));
+    obj = g_list_reverse(capture_obj.list_obj);
+    if(obj)
+    {
+        while(obj)
+        {
+            printf("Remaining object %s=%d\n", G_OBJECT_TYPE_NAME(obj->data), obj->data);
+            obj = obj->next;
+        }
+        g_list_free(capture_obj.list_obj);
+        printf("Remaining object count=%d\n", capture_obj.count);
+    }
+    else
+    {
+        if(capture_obj.flags & OBJECT_CAPTURED)
+        {
+           printf("All captured object %s were instanciated/finalized\n", g_type_name(capture_obj.type));
+        }
+        else
+        {
+           printf("No object %s were captured\n", g_type_name(capture_obj.type));
+        }
+    }
+
+    capture_obj.flags = 0;   /*  clear flags */
+
+    /* restore original method in relevent class */
+    capture_obj.obj_class->constructor = capture_obj.ori_constructor;
+    capture_obj.obj_class->finalize = capture_obj.ori_finalize;
+    printf("Press \"entry\" to continue");
+	getchar();
+    return TRUE;
+}
+#endif
+
+/*----------------------------------------------------------------------------
+ Ancestry gObject type related functions
+-----------------------------------------------------------------------------*/
 /**
  * swami_util_get_child_types:
  * @type: Type to get all children from
@@ -76,6 +305,9 @@ recurse_types(GType type, GArray *array)
     g_free(child_types);
 }
 
+/*----------------------------------------------------------------------------
+ GValue allocation using slice memory pool
+-----------------------------------------------------------------------------*/
 /**
  * swami_util_new_value:
  *
@@ -102,6 +334,10 @@ swami_util_free_value(GValue *value)
     g_slice_free(GValue, value);
 }
 
+/*----------------------------------------------------------------------------
+ MIDI octave to music octave convertion.
+ MIDI note to music note convertion.
+-----------------------------------------------------------------------------*/
 /*
    MIDI_TO_MUSIC_OFFSET is the offset between music octave number and MIDI
    Actually this offset leads to diapason note A4 (music octave 4) beeing MIDI

--- a/src/plugins/fftune_gui.c
+++ b/src/plugins/fftune_gui.c
@@ -267,11 +267,13 @@ fftune_gui_set_property(GObject *object, guint property_id,
             swami_control_connect(samctrl, fftunegui->root_note_ctrl,
                                   SWAMI_CONTROL_CONN_BIDIR
                                   | SWAMI_CONTROL_CONN_INIT);
+            g_object_unref(samctrl);	/* --ref */
 
             samctrl = swami_get_control_prop_by_name(G_OBJECT(sample), "fine-tune");
             swami_control_connect(samctrl, fftunegui->fine_tune_ctrl,
                                   SWAMI_CONTROL_CONN_BIDIR
                                   | SWAMI_CONTROL_CONN_INIT);
+            g_object_unref(samctrl);	/* --ref */
         }
 
         /* recalculate full zoom */

--- a/src/plugins/fluidsynth.c
+++ b/src/plugins/fluidsynth.c
@@ -1953,8 +1953,6 @@ sfloader_sfont_get_preset(fluid_sfont_t *sfont, int bank,
 
     if(bank == b && prenum == p)
     {
-        g_object_ref(G_OBJECT(sfont_data->wavetbl));   /* ++ inc wavetbl ref */
-
         preset = new_fluid_preset(sfont,
                                   sfloader_active_preset_get_name,
                                   sfloader_active_preset_get_banknum,
@@ -1983,7 +1981,6 @@ sfloader_sfont_get_preset(fluid_sfont_t *sfont, int bank,
 
         preset_data = g_malloc0(sizeof(sfloader_preset_data_t));
 
-        g_object_ref(G_OBJECT(sfont_data->wavetbl));   /* ++ inc wavetbl ref */
         preset_data->wavetbl = sfont_data->wavetbl;
 
         preset_data->item = item; /* !! item already referenced by find */
@@ -2010,9 +2007,6 @@ sfloader_preset_free(fluid_preset_t *preset)
 
     /* -- remove item reference */
     g_object_unref(IPATCH_ITEM(preset_data->item));
-
-    /* remove wavetable object reference */
-    g_object_unref(G_OBJECT(preset_data->wavetbl));
 
     g_free(preset_data);
     delete_fluid_preset(preset);

--- a/src/plugins/fluidsynth_gui.c
+++ b/src/plugins/fluidsynth_gui.c
@@ -407,7 +407,7 @@ void fluid_synth_gui_control_finalize(GObject *object)
         GSList *c = fsctrl->ctrl_list;
         while(c)
         {
-//            swami_control_disconnect_unref((SwamiControl *)(c->data));
+            swami_control_disconnect_unref((SwamiControl *)(c->data));
             c = c->next;
         }
         g_slist_free (fsctrl->ctrl_list);

--- a/src/plugins/fluidsynth_gui.c
+++ b/src/plugins/fluidsynth_gui.c
@@ -32,6 +32,7 @@
 typedef struct
 {
     GtkVBox parent_instance;
+    GSList *ctrl_list;       /* properties control list */
     GtkWidget *ctrl_widg;
 } FluidSynthGuiControl;
 
@@ -50,6 +51,16 @@ static void fluid_synth_gui_midi_driver_changed(GtkComboBox *combo,
 static GType fluid_synth_gui_control_register_type(SwamiPlugin *plugin);
 static void fluid_synth_gui_control_class_init(FluidSynthGuiControlClass *klass);
 static void fluid_synth_gui_control_init(FluidSynthGuiControl *fsctrl);
+static void fluid_synth_gui_control_finalize(GObject *object);
+
+static GObjectClass *fluid_synth_gui_control_parent_class = NULL;
+
+static GType fluidsynth_gui_type = 0;
+
+#define FLUID_SYNTH_GUI_TYPE_CONTROL   (fluidsynth_gui_type)
+#define FLUID_SYNTH_GUI_CONTROL(obj) \
+       (G_TYPE_CHECK_INSTANCE_CAST((obj), FLUID_SYNTH_GUI_TYPE_CONTROL, \
+        FluidSynthGuiControl))
 
 SWAMI_PLUGIN_INFO(plugin_fluidsynth_gui_init, NULL);
 
@@ -81,7 +92,7 @@ plugin_fluidsynth_gui_init(SwamiPlugin *plugin, GError **err)
                  NULL);
 
     /* initialize types */
-    fluid_synth_gui_control_register_type(plugin);
+    fluidsynth_gui_type = fluid_synth_gui_control_register_type(plugin);
 //  fluid_synth_gui_map_register_type (plugin);
 //  fluid_synth_gui_channels_register_type (plugin);
 
@@ -280,6 +291,10 @@ fluid_synth_gui_control_register_type(SwamiPlugin *plugin)
 static void
 fluid_synth_gui_control_class_init(FluidSynthGuiControlClass *klass)
 {
+    GObjectClass *obj_class = G_OBJECT_CLASS (klass);
+    fluid_synth_gui_control_parent_class = g_type_class_peek_parent (klass);
+
+    obj_class->finalize = fluid_synth_gui_control_finalize;
 }
 
 static void
@@ -311,6 +326,7 @@ fluid_synth_gui_control_init(FluidSynthGuiControl *fsctrl)
     gtk_widget_show(fsctrl->ctrl_widg);
     gtk_box_pack_start(GTK_BOX(fsctrl), fsctrl->ctrl_widg, FALSE, FALSE, 0);
 
+    /* ++ref, must be unref */
     wavetbl = (SwamiWavetbl *)swami_object_get_by_type(G_OBJECT(swamigui_root),
               "WavetblFluidSynth");     // ++ ref wavetbl
 
@@ -326,32 +342,77 @@ fluid_synth_gui_control_init(FluidSynthGuiControl *fsctrl)
         widg = swamigui_util_glade_lookup(fsctrl->ctrl_widg, namebuf);
         adj = swamigui_knob_get_adjustment(SWAMIGUI_KNOB(widg));
 
+        /* ++ref */
         propctrl = swami_get_control_prop_by_name(G_OBJECT(wavetbl), propnames[i]);
+        /* ++ref */
         widgctrl = SWAMI_CONTROL(swamigui_control_adj_new(adj));
 
+        /* connect property control to widget control */
         swami_control_connect(propctrl, widgctrl, SWAMI_CONTROL_CONN_BIDIR
                               | SWAMI_CONTROL_CONN_INIT | SWAMI_CONTROL_CONN_SPEC);
+
+        /* memorize controls. they must be freed on finalize */
+        fsctrl->ctrl_list = g_slist_append(fsctrl->ctrl_list, propctrl);
+        fsctrl->ctrl_list = g_slist_append(fsctrl->ctrl_list, widgctrl);
     }
 
+    /* ++Ref  */
     propctrl = swami_get_control_prop_by_name(G_OBJECT(wavetbl), "synth.reverb.active");
     widg = swamigui_util_glade_lookup(fsctrl->ctrl_widg, "BtnReverb");
+    /* widget control is owned by the widget (it will be freed when the widget
+       will be destroyed) */
     widgctrl = swamigui_control_new_for_widget(G_OBJECT(widg));
+    /* connect property control to widget control */
     swami_control_connect(propctrl, widgctrl, SWAMI_CONTROL_CONN_BIDIR
                           | SWAMI_CONTROL_CONN_INIT | SWAMI_CONTROL_CONN_SPEC);
+    /* memorize property control. It must be freed on finalize */
+    fsctrl->ctrl_list = g_slist_append(fsctrl->ctrl_list, propctrl);
 
+    /* ++Ref  */
     propctrl = swami_get_control_prop_by_name(G_OBJECT(wavetbl), "synth.chorus.active");
     widg = swamigui_util_glade_lookup(fsctrl->ctrl_widg, "BtnChorus");
+    /* widget control is owned by the widget (it will be freed when the widget
+       will be destroyed) */
     widgctrl = swamigui_control_new_for_widget(G_OBJECT(widg));
+    /* connect property control to widget control */
     swami_control_connect(propctrl, widgctrl, SWAMI_CONTROL_CONN_BIDIR
                           | SWAMI_CONTROL_CONN_INIT | SWAMI_CONTROL_CONN_SPEC);
+    /* memorize property control. It must be freed on finalize */
+    fsctrl->ctrl_list = g_slist_append(fsctrl->ctrl_list, propctrl);
 
     widg = swamigui_util_glade_lookup(fsctrl->ctrl_widg, "ComboChorusType");
+    /* ++Ref  */
     propctrl = swami_get_control_prop_by_name(G_OBJECT(wavetbl), "chorus-waveform");
     type = g_type_from_name("WavetblFluidSynthChorusWaveform");
+    /* widget control is owned by the widget (it will be freed when the widget
+       will be destroyed) */
     widgctrl = swamigui_control_new_for_widget_full(G_OBJECT(widg), type, NULL, 0);
+    /* connect property control to widget control */
     swami_control_connect(propctrl, widgctrl, SWAMI_CONTROL_CONN_BIDIR
                           | SWAMI_CONTROL_CONN_INIT | SWAMI_CONTROL_CONN_SPEC);
+    /* memorize property control. It must be freed on finalize */
+    fsctrl->ctrl_list = g_slist_append(fsctrl->ctrl_list, propctrl);
 
     g_object_unref(wavetbl);      // -- unref wavetbl
 }
 
+/* finalization */
+static
+void fluid_synth_gui_control_finalize(GObject *object)
+{
+    FluidSynthGuiControl *fsctrl = FLUID_SYNTH_GUI_CONTROL(object);
+
+    /* disconnect and free properties controls */
+    {
+        GSList *c = fsctrl->ctrl_list;
+        while(c)
+        {
+//            swami_control_disconnect_unref((SwamiControl *)(c->data));
+            c = c->next;
+        }
+        g_slist_free (fsctrl->ctrl_list);
+    }
+
+    /* chain to parent member finalize */
+    G_OBJECT_CLASS (fluid_synth_gui_control_parent_class)->finalize (object);
+}

--- a/src/swamigui/SwamiguiLoopFinder.c
+++ b/src/swamigui/SwamiguiLoopFinder.c
@@ -134,7 +134,7 @@ swamigui_loop_finder_init(SwamiguiLoopFinder *finder)
     /* create the loop finder object (!! takes over ref) */
     finder->loop_finder = swami_loop_finder_new();
 
-    /* call back to cancel loop finder task when finder is detroyed */
+    /* call back to cancel loop finder task when finder is destroyed */
     g_signal_connect(finder, "destroy",
                      G_CALLBACK(swamigui_loop_finder_destroy), NULL);
 

--- a/src/swamigui/SwamiguiLoopFinder.c
+++ b/src/swamigui/SwamiguiLoopFinder.c
@@ -61,7 +61,7 @@ static void swamigui_loop_finder_get_property(GObject *object,
         GParamSpec *pspec);
 static void swamigui_loop_finder_init(SwamiguiLoopFinder *editor);
 static void swamigui_loop_finder_finalize(GObject *object);
-static void swamigui_loop_finder_destroy(GtkObject *object);
+static void swamigui_loop_finder_destroy(GtkObject *widg, gpointer b);
 static void
 swamigui_loop_finder_cb_selection_changed(GtkTreeSelection *selection,
         gpointer user_data);
@@ -85,8 +85,6 @@ swamigui_loop_finder_class_init(SwamiguiLoopFinderClass *klass)
     obj_class->set_property = swamigui_loop_finder_set_property;
     obj_class->get_property = swamigui_loop_finder_get_property;
     obj_class->finalize = swamigui_loop_finder_finalize;
-
-    gtkobj_class->destroy = swamigui_loop_finder_destroy;
 
     g_object_class_install_property(obj_class, PROP_FINDER,
                                     g_param_spec_object("finder", _("Finder"),
@@ -135,6 +133,10 @@ swamigui_loop_finder_init(SwamiguiLoopFinder *finder)
 
     /* create the loop finder object (!! takes over ref) */
     finder->loop_finder = swami_loop_finder_new();
+
+    /* call back to cancel loop finder task when finder is detroyed */
+    g_signal_connect(finder, "destroy",
+                     G_CALLBACK(swamigui_loop_finder_destroy), NULL);
 
     /* create result list store */
     finder->store = gtk_list_store_new(4, G_TYPE_INT, G_TYPE_INT, G_TYPE_INT,
@@ -243,7 +245,7 @@ swamigui_loop_finder_finalize(GObject *object)
 
 /* loop finder widget destroy */
 static void
-swamigui_loop_finder_destroy(GtkObject *object)
+swamigui_loop_finder_destroy (GtkObject *object, gpointer data)
 {
     SwamiguiLoopFinder *finder = SWAMIGUI_LOOP_FINDER(object);
 

--- a/src/swamigui/SwamiguiModEdit.c
+++ b/src/swamigui/SwamiguiModEdit.c
@@ -522,7 +522,8 @@ swamigui_mod_edit_finalize(GObject *object)
 {
     SwamiguiModEdit *modedit = SWAMIGUI_MOD_EDIT(object);
 
-    g_object_unref(modedit->modctrl);
+    /* disconnect and unref the control */
+	swami_control_disconnect_unref(modedit->modctrl);
 
     if(modedit->selection)
     {

--- a/src/swamigui/SwamiguiPanelSF2Gen.c
+++ b/src/swamigui/SwamiguiPanelSF2Gen.c
@@ -349,7 +349,6 @@ swamigui_panel_sf2_gen_real_set_selection(SwamiguiPanelSF2Gen *genpanel,
         IpatchList *selection)
 {
     IpatchSF2GenItemIface *geniface;
-    IpatchSF2GenArray *genarray;
     GenWidgets *genwidgets;
     int seltype = SEL_NONE;
     SwamiControl *widgctrl, *propctrl;
@@ -407,10 +406,6 @@ swamigui_panel_sf2_gen_real_set_selection(SwamiguiPanelSF2Gen *genpanel,
     else	/* selection is active */
     {
         item = G_OBJECT(selection->items->data);
-
-        /* allocate generator array and fill with all gens from item */
-        genarray = ipatch_sf2_gen_array_new(FALSE);	/* ++ alloc */
-        ipatch_sf2_gen_item_copy_all(IPATCH_SF2_GEN_ITEM(item), genarray);
 
         genwidgets = (GenWidgets *)(genpanel->genwidgets);
         ctrlndx = 0;

--- a/src/swamigui/SwamiguiPanelSF2Gen.c
+++ b/src/swamigui/SwamiguiPanelSF2Gen.c
@@ -179,6 +179,11 @@ swamigui_panel_sf2_gen_finalize(GObject *object)
         g_object_unref(genpanel->selection);
     }
 
+    /* jjc - free genwidgets table allocated at initialization
+       (in swamigui_panel_sf2_gen_set_controls())
+    */
+    g_free(genpanel->genwidgets);
+
     G_OBJECT_CLASS(swamigui_panel_sf2_gen_parent_class)->finalize(object);
 }
 

--- a/src/swamigui/SwamiguiRoot.c
+++ b/src/swamigui/SwamiguiRoot.c
@@ -283,6 +283,55 @@ swamigui_init(int *argc, char **argv[])
     swamigui_register_prop_glade_widg(IPATCH_TYPE_SLI_ZONE, "PropSF2IZone");
     swamigui_register_prop_glade_widg(IPATCH_TYPE_SLI_SAMPLE, "PropSF2Sample");
 
+#if capture_object  // for debugging
+/* Start capture of object (for debugging) (see libswami - util.c for details) */
+//------- libswamigui
+//    start_count_obj("SwamiguiBar");           // to be checked
+//    start_count_obj("SwamiguiBarPtr");        // to be checked
+//    start_count_obj("SwamiguiControlAdj");    // to be checked
+//    start_count_obj("SwamiguiControlFlags");  // (Invalid type, Flags)
+//    start_count_obj("SwamiguiControlMidiKey"); // to be checked
+//    start_count_obj("SwamiguiControlObjectFlags"); //(Invalid type, Flags)
+//    start_count_obj("SwamiguiControlRank");   //(Invalid type, Enums)
+//    start_count_obj("SwamiguiItemMenu");      // to be checked
+//    start_count_obj("SwamiguiKnob");          // to be checked
+//    start_count_obj("SwamiguiMenu");          // to be checked
+//    start_count_obj("SwamiguiModEdit");       // to be checked
+//    start_count_obj("SwamiguiPanel");         // (Invalid type, interface)
+//    start_count_obj("SwamiguiPanelSelector"); // to be checked
+//    start_count_obj("SwamiguiPanelSF2Gen");   // to be checked
+//    start_count_obj("SwamiguiProp");          // to be checked
+//    start_count_obj("SwamiguiSampleEditor");  // to be checked
+//    start_count_obj("SwamiguiPanelSF2GenMisc"); // to be checked
+//    start_count_obj("SwamiguiPanelSF2GenEnv");  // to be checked
+//    start_count_obj("SwamiguiModEdit");       // to be checked
+//    start_count_obj("SwamiguiPasteDecision"); // (Invalid type, Flags)
+//    start_count_obj("SwamiguiPaste");         // to be checked
+//    start_count_obj("SwamiguiPasteStatus");   // (Invalid type, Enums)
+//    start_count_obj("SwamiguiPiano");         // to be checked
+//    start_count_obj("SwamiguiPref");          // to be checked
+//    start_count_obj("SwamiguiQuitConfirm");   // (Invalid type, Enums)
+//    start_count_obj("SwamiguiRoot");          // to be checked
+//    start_count_obj("SwamiguiSampleCanvas");   //to be checked
+//    start_count_obj("SwamiguiSampleEditorMarkerFlags"); // Invalide, Flags
+//    start_count_obj("SwamiguiSampleEditorMarkerId");    // (Invalid type, Enums)
+//    start_count_obj("SwamiguiSampleEditorStatus");      // (Invalid type, Enums)
+//    start_count_obj("SwamiguiSpectrumCanvas");  // to be checked
+//    start_count_obj("SwamiguiSpinScale");       // to be checked
+//    start_count_obj("SwamiguiSplits");          // to be checked
+//    start_count_obj("SwamiguiSplitsMode");      // (Invalid type, Enums)
+//    start_count_obj("SwamiguiSplitsStatus");    // (Invalid type, Enums)
+//    start_count_obj("SwamiguiStatusBar");       //(Invalid type, Enums)
+//    start_count_obj("SwamiguiStatusBarPos");    // (Invalid type, Enums)
+//    start_count_obj("SwamiguiTree");            // to be checked
+//    start_count_obj("SwamiguiTreeStore");       // to be checked
+//    start_count_obj("SwamiguiTreeStorePatch");  // to be checked
+//    start_count_obj("SwamiguiTreeStoreConfig"); // to be checked
+//      (SWAMIGUI_TYPE_CANVAS_MOD);    start_count_obj("SwamiguiCanvasMod"); to be checked
+//    start_count_obj("SwamiguiControlAdj"); //to be checked
+//    start_count_obj("GtkFileChooserButton"); //to be checked
+#endif
+
 #ifdef PYTHON_SUPPORT
 
     if(!swamigui_disable_python)

--- a/src/swamigui/SwamiguiRoot.c
+++ b/src/swamigui/SwamiguiRoot.c
@@ -346,6 +346,7 @@ swamigui_init(int *argc, char **argv[])
     {
         swami_plugin_load_all();    /* load plugins */
     }
+      start_count_obj("WavetblFluidSynth"); //to be checked
 }
 
 /* Function used by libglade to initialize libswamigui widgets */

--- a/src/swamigui/SwamiguiRoot.c
+++ b/src/swamigui/SwamiguiRoot.c
@@ -346,7 +346,7 @@ swamigui_init(int *argc, char **argv[])
     {
         swami_plugin_load_all();    /* load plugins */
     }
-      start_count_obj("WavetblFluidSynth"); //to be checked
+//      start_count_obj("WavetblFluidSynth"); //to be checked
 }
 
 /* Function used by libglade to initialize libswamigui widgets */

--- a/src/swamigui/SwamiguiRoot.c
+++ b/src/swamigui/SwamiguiRoot.c
@@ -890,9 +890,21 @@ swamigui_root_finalize(GObject *object)
         g_source_remove(root->update_timeout_id);
     }
 
-    g_object_unref(root->ctrl_prop);
-    g_object_unref(root->ctrl_add);
-    g_object_unref(root->ctrl_remove);
+    /* disconnect and unref controls */
+    swami_control_disconnect_unref(SWAMI_CONTROL(root->ctrl_prop));
+    swami_control_disconnect_unref(SWAMI_CONTROL(root->ctrl_add));
+    swami_control_disconnect_unref(SWAMI_CONTROL(root->ctrl_remove));
+
+    /* disconnect all (only) properties controls */
+    {
+        GSList *c = root->ctrl_list;
+        while(c)
+        {
+            swami_control_disconnect_all((SwamiControl *)(c->data));
+            c = c->next;
+        }
+        g_slist_free (root->ctrl_list);
+    }
 
     g_free(root->piano_lower_keys);
     g_free(root->piano_upper_keys);
@@ -1488,6 +1500,8 @@ swamigui_root_create_main_window(SwamiguiRoot *root)
 
     /* get root selection property control */
     rootsel_ctrl = swami_get_control_prop_by_name(G_OBJECT(root), "selection");
+    /* rootsel_ctrl must be disconnected on finalization */
+    root->ctrl_list = g_slist_append(root->ctrl_list, rootsel_ctrl);
 
     root->main_window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
     gtk_window_set_default_size(GTK_WINDOW(root->main_window), 1024, 768);
@@ -1679,12 +1693,16 @@ swamigui_root_create_main_window(SwamiguiRoot *root)
 
         g_object_unref(tctrl);  /* -- unref */
         g_object_unref(pctrl);  /* -- unref */
+        /* tctrl must be disconnected on root finalization */
+        root->ctrl_list = g_slist_append(root->ctrl_list, tctrl);
 
         g_signal_connect(root, "notify::selection-single",
                          G_CALLBACK(swamigui_root_cb_solo_item), NULL);
     }
 
     g_object_unref(midihub);	/* -- unref creator's reference */
+    /* midihub must be disconnected on root finalization */
+    root->ctrl_list = g_slist_append(root->ctrl_list, midihub);
 
     gtk_widget_show(root->main_window);
 #ifdef MAC_INTEGRATION

--- a/src/swamigui/SwamiguiRoot.h
+++ b/src/swamigui/SwamiguiRoot.h
@@ -79,6 +79,7 @@ struct _SwamiguiRoot
     SwamiControlFunc *ctrl_prop; /* patch item property change ctrl listener */
     SwamiControlFunc *ctrl_add;	/* patch item add control listener */
     SwamiControlFunc *ctrl_remove; /* patch item remove control listener */
+    GSList *ctrl_list; /* properties controls list created at initialization*/
 
     SwamiguiQuitConfirm quit_confirm; /* quit confirm enum */
     gboolean splash_enable;	/* show splash on startup? */

--- a/src/swamigui/main.c
+++ b/src/swamigui/main.c
@@ -199,6 +199,15 @@ main(int argc, char *argv[])
     gtk_main();			/* kick it in the main GTK loop */
     gdk_threads_leave();
 
+    /*
+      Removing allocated value in proptree. (This value were added in root initialization.
+      Unfortunately, this cannot be done in root finalization  because proptree is destroyed
+      in a weak ref callback called  when root is destroyed. (the callback is called before
+      finalize).
+    */
+    swami_prop_tree_remove_value(SWAMI_ROOT(root)->proptree, G_OBJECT (root), 0, "item-selection");
+    swami_prop_tree_remove_value(SWAMI_ROOT(root)->proptree, G_OBJECT (root), 0, "store-list");
+
     /* we destroy it all so refdbg can tell us what objects leaked */
     g_object_unref(root);	/* -- unref root */
 

--- a/src/swamigui/main.c
+++ b/src/swamigui/main.c
@@ -19,6 +19,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
  * 02111-1307, USA or point your web browser to http://www.gnu.org.
  */
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -201,6 +202,10 @@ main(int argc, char *argv[])
     /* we destroy it all so refdbg can tell us what objects leaked */
     g_object_unref(root);	/* -- unref root */
 
+#if capture_object
+	/* Stop capture of object (for debugging) */
+    stop_count_obj();
+#endif
     exit(0);
 }
 

--- a/src/swamigui/util.c
+++ b/src/swamigui/util.c
@@ -187,6 +187,9 @@ swamigui_util_register_unique_dialog(GtkWidget *dialog, gchar *strkey,
 
     gtk_window_set_transient_for(GTK_WINDOW(dialog), GTK_WINDOW(swamigui_root->main_window));
 
+    /* destroy opened dialog when the main window is destroyed */
+    gtk_window_set_destroy_with_parent((GtkWindow*)dialog, TRUE);
+
     udkey.dialog = dialog;
     udkey.strkey = strkey;
     udkey.key2 = key2;


### PR DESCRIPTION
`SwamiControl `objects and friends are particularly sensible leading into frequent memory leak due to missing call to **g_object_unref()** when the application exit.
This PR provide a debugging capture API in `libswami-util.c` that should help to catch missing **g_object_unref** in next commits comming soon.