### PR TITLE
Add deinitialization functions in Swami

### DIFF
--- a/src/libswami/SwamiPlugin.c
+++ b/src/libswami/SwamiPlugin.c
@@ -55,6 +55,7 @@ static GList *plugin_paths = NULL; /* plugin search paths */
 static GObjectClass *parent_class = NULL;
 
 
+static void swami_plugin_free_plugin_path(char *path, gpointer user_data);
 static void swami_plugin_class_init(SwamiPluginClass *klass);
 static void swami_plugin_finalize(GObject *object);
 static void swami_plugin_set_property(GObject *object, guint property_id,
@@ -65,6 +66,8 @@ static gboolean swami_plugin_type_module_load(GTypeModule *type_module);
 static void swami_plugin_type_module_unload(GTypeModule *type_module);
 static gboolean swami_plugin_load_recurse(char *file, char *name);
 
+/* default plugins directory */
+static const char * plugin_dir = PLUGINS_DIR;
 
 /* initialize plugin system */
 void
@@ -105,7 +108,7 @@ _swami_plugin_initialize(void)
     }
     else
     {
-        plugin_paths = g_list_append(plugin_paths, g_strdup(PLUGINS_DIR));
+        plugin_paths = g_list_append (plugin_paths, (gpointer)plugin_dir);
     }
 }
 
@@ -721,10 +724,19 @@ void
 _swami_plugin_deinitialize(void)
 {
     /* free plugings_path list */
-    g_list_foreach(plugin_paths, (GFunc)g_free, NULL);
+    g_list_foreach(plugin_paths, (GFunc)swami_plugin_free_plugin_path, NULL);
     g_list_free(plugin_paths);
 
     /* free swami_plugins list */
     g_list_free(swami_plugins);
+}
+
+/* free path */
+static void swami_plugin_free_plugin_path(char *path, gpointer user_data)
+{
+    if(path != plugin_dir)
+    {
+        g_free(path);
+    }
 }
 

--- a/src/libswami/SwamiPlugin.c
+++ b/src/libswami/SwamiPlugin.c
@@ -67,7 +67,7 @@ static void swami_plugin_type_module_unload(GTypeModule *type_module);
 static gboolean swami_plugin_load_recurse(char *file, char *name);
 
 /* default plugins directory */
-static const char * plugin_dir = PLUGINS_DIR;
+static const char * plugins_dir = PLUGINS_DIR;
 
 /* initialize plugin system */
 void
@@ -108,7 +108,7 @@ _swami_plugin_initialize(void)
     }
     else
     {
-        plugin_paths = g_list_append (plugin_paths, (gpointer)plugin_dir);
+        plugin_paths = g_list_append (plugin_paths, (gpointer)plugins_dir);
     }
 }
 
@@ -734,7 +734,7 @@ _swami_plugin_deinitialize(void)
 /* free path */
 static void swami_plugin_free_plugin_path(char *path, gpointer user_data)
 {
-    if(path != plugin_dir)
+    if(path != plugins_dir)
     {
         g_free(path);
     }

--- a/src/libswami/SwamiPlugin.c
+++ b/src/libswami/SwamiPlugin.c
@@ -105,7 +105,7 @@ _swami_plugin_initialize(void)
     }
     else
     {
-        plugin_paths = g_list_append(plugin_paths, PLUGINS_DIR);
+        plugin_paths = g_list_append(plugin_paths, g_strdup(PLUGINS_DIR));
     }
 }
 
@@ -696,3 +696,35 @@ swami_plugin_load_xml(SwamiPlugin *plugin, GNode *xmlnode, GError **err)
 
     return (plugin->load_xml(plugin, xmlnode, err));
 }
+
+/*------------------ unloading plugins---------------------------------------*/
+/**
+ * swami_plugin_unload_all:
+ *
+ * Unload all plugins registered in swami_plugins list.
+ */
+void
+swami_plugin_unload_all(void)
+{
+    GList *plugins = swami_plugins;
+    /* Unload modules */
+    while (plugins)
+    {
+        /* unload plugin module */
+        g_type_module_unuse(G_TYPE_MODULE(plugins->data));
+//      g_object_unref (plugin);
+        plugins = g_list_next(plugins);
+    }
+}
+
+void
+_swami_plugin_deinitialize(void)
+{
+    /* free plugings_path list */
+    g_list_foreach(plugin_paths, (GFunc)g_free, NULL);
+    g_list_free(plugin_paths);
+
+    /* free swami_plugins list */
+    g_list_free(swami_plugins);
+}
+

--- a/src/libswami/libswami.c
+++ b/src/libswami/libswami.c
@@ -218,10 +218,10 @@ swami_deinit()
     ipatch_container_add_disconnect_matched (NULL, container_add_notify, NULL);
     ipatch_container_remove_disconnect_matched (NULL, NULL, container_remove_notify, NULL);
 
-    /* free SwamiControl object */
-    g_object_unref(swami_patch_prop_title_control);
-    g_object_unref(swami_patch_add_control);
-    g_object_unref(swami_patch_remove_control);
+    /* Force control deconnections and free SwamiControl object */
+    swami_control_disconnect_unref(swami_patch_prop_title_control);
+    swami_control_disconnect_unref(swami_patch_add_control);
+    swami_control_disconnect_unref(swami_patch_remove_control);
 
     /* free plugins system */
     _swami_plugin_deinitialize();

--- a/src/libswami/libswami.c
+++ b/src/libswami/libswami.c
@@ -48,8 +48,13 @@ static void container_remove_notify(IpatchContainer *container,
 /* local libswami prototypes (in separate source files) */
 
 void _swami_object_init(void);	/* SwamiObject.c */
+void _swami_object_deinit(void);	/* SwamiObject.c */
 void _swami_plugin_initialize(void);  /* SwamiPlugin.c */
+void _swami_plugin_deinitialize(void); /* SwamiPlugin.c */
 void _swami_value_transform_init(void);  /* value_transform.c */
+
+/* indicates that the librarie is initialized */
+static gboolean initialized = FALSE;
 
 /* Ipatch property and container add/remove event controls */
 /* public variables */
@@ -57,6 +62,8 @@ void _swami_value_transform_init(void);  /* value_transform.c */
 SwamiControl *swami_patch_prop_title_control;
 SwamiControl *swami_patch_add_control;
 SwamiControl *swami_patch_remove_control;
+
+static guint event_timeout_id;
 
 /*
  Getter function returning swami_patch_prop_title_control.
@@ -88,6 +95,18 @@ swami_patch_get_remove_control(void)
     return swami_patch_remove_control;
 }
 
+/*-----------------------------------------------------------------------------
+ Initialization / deinitialization of libswami library.
+ Any application should call swami_init() once before any other libswami
+ functions.
+ When the application is complete it must call swami_deinit.
+
+ For multi task application it is best that only one task be responsible of
+ initialization/deinitialization. Typically, the main task of the application
+ should call swami_init() before creating other tasks, then when the application
+ is complete the main task should call swami_deinit() after the other tasks are
+ completed.
+s-----------------------------------------------------------------------------*/
 /**
  * swami_init:
  *
@@ -96,7 +115,6 @@ swami_patch_get_remove_control(void)
 void
 swami_init(void)
 {
-    static gboolean initialized = FALSE;
     char *swap_dir, *swap_filename;
 
     if(initialized)
@@ -152,12 +170,13 @@ swami_init(void)
                                     NULL, NULL);
 
     /* install periodic control event expiration process */
-    g_timeout_add(SWAMI_CONTROL_EVENT_EXPIRE_INTERVAL,
-                  swami_control_event_expire_timeout, NULL);
+    event_timeout_id = g_timeout_add (SWAMI_CONTROL_EVENT_EXPIRE_INTERVAL,
+                                      swami_control_event_expire_timeout, NULL);
 
-    /* Construct Swami directory name for swap file (uses XDG cache directory - seems the most appropriate) */
     swap_dir = g_build_filename(g_get_user_cache_dir(), "swami", NULL);	/* ++ alloc */
 
+    /* Construct Swami directory name for swap file
+	(uses XDG cache directory - seems the most appropriate) */
     if(!g_file_test(swap_dir, G_FILE_TEST_EXISTS))
     {
         if(g_mkdir_with_parents(swap_dir, 0700) == -1)
@@ -169,12 +188,49 @@ swami_init(void)
         }
     }
 
-    swap_filename = g_build_filename(swap_dir, "sample_swap.dat", NULL);	/* ++ alloc */
+    /* ++ alloc */
+    swap_filename = g_build_filename(swap_dir, "sample_swap.dat", NULL);
     g_free(swap_dir);	/* -- free swap dir */
 
     /* assign libInstPatch sample store swap file name (uses XDG cache directory) */
     ipatch_set_sample_store_swap_file_name(swap_filename);
     g_free(swap_filename);        // -- free swap file name
+}
+
+/**
+ * swami_deinit:
+ *
+ * Free libSwami. Should be called when the application finished using libswami.
+ */
+void
+swami_deinit()
+{
+    if (!initialized)
+    {
+        return; /* does nothing because swami has not been initialized */
+    }
+    initialized = FALSE;
+
+    /* cancel SwamiControl event queuing timer */
+    g_source_remove (event_timeout_id);
+
+    /* disconnect notify from container */
+    ipatch_container_add_disconnect_matched (NULL, container_add_notify, NULL);
+    ipatch_container_remove_disconnect_matched (NULL, NULL, container_remove_notify, NULL);
+
+    /* free SwamiControl object */
+    g_object_unref(swami_patch_prop_title_control);
+    g_object_unref(swami_patch_add_control);
+    g_object_unref(swami_patch_remove_control);
+
+    /* free plugins system */
+    _swami_plugin_deinitialize();
+
+    /* free child properties and type rank systems */
+    _swami_object_deinit();
+
+    /* free libInstPatch */
+    ipatch_close();
 }
 
 static gboolean

--- a/src/libswami/libswami.def
+++ b/src/libswami/libswami.def
@@ -1,6 +1,8 @@
 LIBRARY
 EXPORTS
 
+swami_deinit
+
 _swami_object_init
 ;_swami_param_init
 

--- a/src/libswami/libswami.def
+++ b/src/libswami/libswami.def
@@ -7,6 +7,7 @@ _swami_object_init
 ;_swami_param_init
 
 _swami_plugin_initialize
+swami_plugin_unload_all
 
 _swami_ret_g_log
 

--- a/src/swamigui/SwamiguiControl.c
+++ b/src/swamigui/SwamiguiControl.c
@@ -72,6 +72,8 @@ typedef struct
 
 static int swamigui_control_GCompare_type(gconstpointer a, gconstpointer b);
 static int swamigui_control_GCompare_rank(gconstpointer a, gconstpointer b);
+static void
+_swami_control_free_handler_infos(HandlerInfo *data, gpointer user_data);
 
 
 G_LOCK_DEFINE_STATIC(control_handlers);
@@ -80,11 +82,30 @@ static GList *control_handlers = NULL;
 /* quark used to associate a control to a widget using g_object_set_qdata */
 GQuark swamigui_control_quark = 0;
 
+/* ------ Initialization/deinitialization of GUI control system --------------*/
+/* Ininitialize GUI control system */
 void
 _swamigui_control_init(void)
 {
+    control_handlers = NULL;
+
     swamigui_control_quark
         = g_quark_from_static_string("_SwamiguiControl");
+}
+
+/* Free GUI control system */
+void
+_swamigui_control_deinit(void)
+{
+    g_list_foreach(control_handlers,
+                   (GFunc)_swami_control_free_handler_infos, NULL);
+    g_list_free(control_handlers);
+}
+
+static void
+_swami_control_free_handler_infos(HandlerInfo *data, gpointer user_data)
+{
+    g_slice_free(HandlerInfo, data);
 }
 
 /**

--- a/src/swamigui/SwamiguiItemMenu.c
+++ b/src/swamigui/SwamiguiItemMenu.c
@@ -105,6 +105,16 @@ _swamigui_item_menu_init(void)
                              NULL, type_match_list_free);
 }
 
+/* free menu table */
+void
+_swamigui_item_menu_deinit (void)
+{
+    g_hash_table_destroy(menu_action_hash);
+    g_hash_table_destroy(item_type_include_hash);
+    g_hash_table_destroy(item_type_exclude_hash);
+    g_object_unref(swamigui_item_menu_accel_group);
+}
+
 GType
 swamigui_item_menu_get_type(void)
 {

--- a/src/swamigui/SwamiguiPanelSelector.c
+++ b/src/swamigui/SwamiguiPanelSelector.c
@@ -40,6 +40,8 @@ typedef struct
     int order;		/* Sort order for this panel type */
 } PanelInfo;
 
+static void
+_swamigui_panel_selector_free_panel_infos(PanelInfo *data, gpointer user_data);
 
 static void swamigui_panel_selector_set_property(GObject *object,
         guint property_id,
@@ -63,11 +65,34 @@ static void swamigui_panel_selector_insert_panel(SwamiguiPanelSelector *selector
 
 G_DEFINE_TYPE(SwamiguiPanelSelector, swamigui_panel_selector, GTK_TYPE_NOTEBOOK);
 
-static GList *panel_list = NULL;	/* list of registered panels (PanelInfo *) */
-static guint panel_count = 0;		/* count of items in panel_list */
+static GList *panel_list = NULL;  /* list of registered panels (PanelInfo *) */
+static guint panel_count = 0;     /* count of items in panel_list */
 
 #define swamigui_panel_selector_info_new()	g_slice_new (PanelInfo)
 
+/* ----------  Initialization/deinitialization of pannel list ----------------*/
+void
+_swamigui_panel_selector_init()
+{
+    panel_list = NULL; /* list of registered panels (PanelInfo structure) */
+    panel_count = 0;   /* count of items in panel_list */
+}
+
+void
+_swamigui_panel_selector_deinit()
+{
+    g_list_foreach(panel_list,
+                   (GFunc)_swamigui_panel_selector_free_panel_infos, NULL);
+    g_list_free(panel_list);
+}
+
+static void
+_swamigui_panel_selector_free_panel_infos(PanelInfo *data, gpointer user_data)
+{
+    g_slice_free(PanelInfo, data);
+}
+
+/* --------------------------------------------------------------------------*/
 
 /**
  * swamigui_get_panel_selector_types:

--- a/src/swamigui/SwamiguiProp.c
+++ b/src/swamigui/SwamiguiProp.c
@@ -91,6 +91,23 @@ prop_info_free(gpointer data)
     g_slice_free(PropInfo, data);
 }
 
+/* ----------  Initialization/deinitialization of property type registry ----*/
+/* Initialization of property type registry */
+void
+_swamigui_prop_init(void)
+{
+    prop_registry = g_hash_table_new_full (NULL, NULL, NULL, prop_info_free);
+}
+
+/* Freeing of property type registry */
+void
+_swamigui_prop_deinit(void)
+{
+    g_hash_table_destroy(prop_registry);
+}
+
+/* --------------------------------------------------------------------------*/
+
 /**
  * swamigui_register_prop_glade_widg:
  * @objtype: Type of object which the interface will control
@@ -162,8 +179,6 @@ swamigui_prop_get_type(void)
         obj_type = g_type_register_static(GTK_TYPE_SCROLLED_WINDOW,
                                           "SwamiguiProp", &obj_info, 0);
         g_type_add_interface_static(obj_type, SWAMIGUI_TYPE_PANEL, &panel_info);
-
-        prop_registry = g_hash_table_new_full(NULL, NULL, NULL, prop_info_free);
     }
 
     return (obj_type);

--- a/src/swamigui/libswamigui.def
+++ b/src/swamigui/libswamigui.def
@@ -1,6 +1,8 @@
 LIBRARY
 EXPORTS
 
+swamigui_deinit
+
 swamigui_control_glade_prop_connect
 swamigui_spectrum_canvas_get_type
 swamigui_control_adj_new

--- a/src/swamigui/main.c
+++ b/src/swamigui/main.c
@@ -46,7 +46,7 @@ static void log_python_output_func(const char *output, gboolean is_stderr);
 /* global boolean feature hacks */
 extern gboolean swamigui_disable_python;
 extern gboolean swamigui_disable_plugins;
-
+extern void  swamigui_deinit(void);
 
 int
 main(int argc, char *argv[])
@@ -210,6 +210,9 @@ main(int argc, char *argv[])
 
     /* we destroy it all so refdbg can tell us what objects leaked */
     g_object_unref(root);	/* -- unref root */
+
+    /* deinitialization of swamigui library */
+    swamigui_deinit();
 
     exit(0);
 }

--- a/src/swamigui/util.c
+++ b/src/swamigui/util.c
@@ -90,6 +90,12 @@ swamigui_util_init(void)
     //  g_timeout_add (LOG_POPUP_CHECK_INTERVAL, (GSourceFunc)log_check_popup, NULL);
 }
 
+void
+swamigui_util_deinit(void)
+{
+    g_array_free(unique_dialog_array, TRUE);
+}
+
 guint
 swamigui_util_unit_rgba_color_get_type(void)
 {


### PR DESCRIPTION
The new fonctions are `swami_deinit()` and `swamigui_deinit()`
-  `swami_deinit() `does the reverse job done by `swami_init()`. It frees memory
and calls `ipatch_close() `(see https://github.com/swami/libinstpatch/pull/40#pullrequestreview-392254836).
- Similarly `swamigui_deinit()` does the reverse of `swamigui_init(),` and calls `swami_deinit()`.
- Swami application calls `swamigui_init() / swamigui_denit()`.