### PR TITLE
fix g_object_unref(knob_pixbuf)

### DIFF
--- a/src/swamigui/SwamiguiKnob.c
+++ b/src/swamigui/SwamiguiKnob.c
@@ -73,7 +73,10 @@ void _swamigui_knob_init(void)
  */
 void _swamigui_knob_deinit(void)
 {
-    g_object_unref(knob_pixbuf);
+    if(knob_pixbuf != NULL)
+    {
+        g_object_unref(knob_pixbuf);
+    }
 }
 
 /*----- SwamiguiKnob object functions ---------------------------------------*/


### PR DESCRIPTION
`knob_pixbuf` is created only if fluidsynth GUI plugin is loaded, otherwise it is NULL.
