### PR TITLE
Missing freeing of plugins

### DIFF
--- a/src/libswami/SwamiPlugin.c
+++ b/src/libswami/SwamiPlugin.c
@@ -704,7 +704,7 @@ swami_plugin_load_xml(SwamiPlugin *plugin, GNode *xmlnode, GError **err)
 /**
  * swami_plugin_unload_all:
  *
- * Unload all plugins registered in swami_plugins list.
+ * Unload and free all plugins registered in swami_plugins list.
  */
 void
 swami_plugin_unload_all(void)
@@ -715,11 +715,15 @@ swami_plugin_unload_all(void)
     {
         /* unload plugin module */
         g_type_module_unuse(G_TYPE_MODULE(plugins->data));
-//      g_object_unref (plugin);
+
+        /* free plugin */
+        g_object_unref(plugins->data);
+
         plugins = g_list_next(plugins);
     }
 }
 
+/* deinitialize plugin system */
 void
 _swami_plugin_deinitialize(void)
 {

--- a/src/plugins/fftune.c
+++ b/src/plugins/fftune.c
@@ -125,8 +125,12 @@ plugin_fftune_init(SwamiPlugin *plugin, GError **err)
                  "license", "GPL",
                  NULL);
 
-    /* register types */
-    sample_mode_enum_type = sample_mode_register_type(plugin);
+    /* register types (see comment in sample_mode_register_type) */
+    if(!sample_mode_enum_type)
+    {
+        sample_mode_enum_type = sample_mode_register_type(plugin);
+    }
+
     fftune_spectra_get_type();
 
     return (TRUE);
@@ -141,13 +145,12 @@ sample_mode_register_type(SwamiPlugin *plugin)
         { FFTUNE_MODE_LOOP, "FFTUNE_MODE_LOOP", "Loop" },
         { 0, NULL, NULL }
     };
-    static GTypeInfo enum_info = { 0, NULL, NULL, NULL, NULL, NULL, 0, 0, NULL };
 
-    /* initialize the type info structure for the enum type */
-    g_enum_complete_type_info(G_TYPE_ENUM, &enum_info, values);
-
-    return (g_type_module_register_type(G_TYPE_MODULE(plugin), G_TYPE_ENUM,
-                                        "FFTuneSampleMode", &enum_info, 0));
+    /* The type should be registered in the context of the module using
+       g_type_module_register_type(). However the type is registered
+       static otherwhise freeing the plguin will fail.
+    */
+    return g_enum_register_static ("FFTuneSampleMode", values);
 }
 
 static void

--- a/src/plugins/fluidsynth.c
+++ b/src/plugins/fluidsynth.c
@@ -411,10 +411,21 @@ plugin_fluidsynth_init(SwamiPlugin *plugin, GError **err)
     delete_fluid_settings(settings);
 
 
-    /* initialize types */
-    wavetbl_type = wavetbl_register_type(plugin);
-    interp_mode_type = interp_mode_register_type(plugin);
-    chorus_waveform_type = chorus_waveform_register_type(plugin);
+    /* initialize types (see comment in wavetbl_register_type) */
+    if(!wavetbl_type)
+    {
+        wavetbl_type = wavetbl_register_type(plugin);
+    }
+
+    if(!interp_mode_type)
+    {
+        interp_mode_type = interp_mode_register_type(plugin);
+    }
+
+    if(!chorus_waveform_type)
+    {
+        chorus_waveform_type = chorus_waveform_register_type(plugin);
+    }
 
     return (TRUE);
 }
@@ -511,9 +522,12 @@ wavetbl_register_type(SwamiPlugin *plugin)
         (GInstanceInitFunc) wavetbl_fluidsynth_init,
     };
 
-    return (g_type_module_register_type(G_TYPE_MODULE(plugin),
-                                        SWAMI_TYPE_WAVETBL, "WavetblFluidSynth",
-                                        &obj_info, 0));
+    /* The type should be registered in the context of the module using
+       g_type_module_register_type(). However the type is registered
+       static otherwhise freeing the plguin will fail.
+    */
+    return g_type_register_static(SWAMI_TYPE_WAVETBL, "WavetblFluidSynth",
+                                  &obj_info, 0);
 }
 
 static GType
@@ -539,14 +553,12 @@ interp_mode_register_type(SwamiPlugin *plugin)
         },
         { 0, NULL, NULL }
     };
-    static GTypeInfo enum_info = { 0, NULL, NULL, NULL, NULL, NULL, 0, 0, NULL };
 
-    /* initialize the type info structure for the enum type */
-    g_enum_complete_type_info(G_TYPE_ENUM, &enum_info, values);
-
-    return (g_type_module_register_type(G_TYPE_MODULE(plugin), G_TYPE_ENUM,
-                                        "WavetblFluidSynthInterpType",
-                                        &enum_info, 0));
+    /* The type should be registered in the context of the module using
+       g_type_module_register_type(). However the type is registered
+       static otherwhise freeing the plguin will fail.
+    */
+    return g_enum_register_static("WavetblFluidSynthInterpType", values);
 }
 
 static GType
@@ -564,14 +576,12 @@ chorus_waveform_register_type(SwamiPlugin *plugin)
         },
         { 0, NULL, NULL }
     };
-    static GTypeInfo enum_info = { 0, NULL, NULL, NULL, NULL, NULL, 0, 0, NULL };
 
-    /* initialize the type info structure for the enum type */
-    g_enum_complete_type_info(G_TYPE_ENUM, &enum_info, values);
-
-    return (g_type_module_register_type(G_TYPE_MODULE(plugin), G_TYPE_ENUM,
-                                        "WavetblFluidSynthChorusWaveform",
-                                        &enum_info, 0));
+    /* The type should be registered in the context of the module using
+       g_type_module_register_type(). However the type is registered
+       static otherwhise freeing the plguin will fail.
+    */
+    return g_enum_register_static("WavetblFluidSynthChorusWaveform", values);
 }
 
 /* used for passing multiple values to FluidSynth foreach function */

--- a/src/plugins/fluidsynth_gui.c
+++ b/src/plugins/fluidsynth_gui.c
@@ -91,8 +91,12 @@ plugin_fluidsynth_gui_init(SwamiPlugin *plugin, GError **err)
                  "license", "GPL",
                  NULL);
 
-    /* initialize types */
-    fluidsynth_gui_type = fluid_synth_gui_control_register_type(plugin);
+    /* register type (see comment in fluid_synth_gui_control_register_type) */
+    if(!fluidsynth_gui_type)
+    {
+        fluidsynth_gui_type = fluid_synth_gui_control_register_type(plugin);
+    }
+
 //  fluid_synth_gui_map_register_type (plugin);
 //  fluid_synth_gui_channels_register_type (plugin);
 
@@ -283,9 +287,12 @@ fluid_synth_gui_control_register_type(SwamiPlugin *plugin)
         (GInstanceInitFunc) fluid_synth_gui_control_init,
     };
 
-    return (g_type_module_register_type(G_TYPE_MODULE(plugin),
-                                        GTK_TYPE_VBOX, "FluidSynthGuiControl",
-                                        &obj_info, 0));
+    /* The type should be registered in the context of the module using
+       g_type_module_register_type(). However the type is registered
+       static otherwhise freeing the plguin will fail.
+    */
+    return g_type_register_static(GTK_TYPE_VBOX, "FluidSynthGuiControl",
+                                  &obj_info, 0);
 }
 
 static void


### PR DESCRIPTION
Actually there are 4 possible plugins created and loaded at swami  initialization.
On `swami_plugin_unload_all()`, these plugins must be unloaded and `freed`. Actually these are only unloaded. This PR allows freeing of these pluging

**Issue**:please note that on first commit `1b2c08c4 `only freeing of `fftune_gui `is successful.
Freeing of `fftune, fluidsynth_gui, fluidsynth_plugin` fail leading in following message:
`GLib-GObject-WARNING **: gtypemodule.c:111: unsolicitated invocation of g_object_run_dispose() on GTypeModule.
`

Following commits  `aa02b04c`, `9bf09a4f`,  `12e1093 `fixes this issue for each respective plugin: `fftune, fluidsynth_gui, fluidsynth_plugin` 