### PR TITLE
Close any open dialog when the application quit

### DIFF
--- a/src/swamigui/SwamiguiRoot.c
+++ b/src/swamigui/SwamiguiRoot.c
@@ -76,6 +76,8 @@ enum
 #define SWAMIGUI_ROOT_DEFAULT_UPPER_KEYS  "q,2,w,3,e,r,5,t,6,y,7,u,i,9,o,0,p,bracketleft,equal,bracketright"
 
 /* external private global prototypes */
+void  swamigui_util_destroy_unique_dialog(void);
+
 void _swamigui_ifaces_init(void);  /* ifaces/ifaces.c */
 void _swamigui_stock_icons_init(void);  /* icons.c */
 void _swamigui_control_init(void);  /* SwamiguiControl.c */
@@ -1125,6 +1127,9 @@ swamigui_root_quit(SwamiguiRoot *root)
     GtkWidget *popup;
     int quit_confirm;
     char *s;
+
+    /* destroy any dialog actally open */
+    swamigui_util_destroy_unique_dialog();
 
     /* Look among "patch items" if one of them has been changed */
     list = swami_root_get_patch_items(SWAMI_ROOT(root));   /* ++ ref list */

--- a/src/swamigui/util.c
+++ b/src/swamigui/util.c
@@ -250,6 +250,26 @@ swamigui_util_activate_unique_dialog(gchar *strkey, gint key2)
     return (FALSE);
 }
 
+/* Destroy any dialog actually open
+
+   This is usually called when the application quit.
+
+   Note: This ensures that all SwamiControl object associated to child widgets
+   inside these dialog are properly disconnected and freed when these child widget
+   are destroyed.
+*/
+void swamigui_util_destroy_unique_dialog()
+{
+    UniqueDialogKey *udkeyp;
+    gint i;
+
+    for (i = unique_dialog_array->len - 1; i >= 0; i--)
+    {
+        udkeyp = &g_array_index(unique_dialog_array, UniqueDialogKey, i);
+        gtk_widget_destroy(GTK_WIDGET(udkeyp->dialog));
+    }
+}
+
 /* run gtk_main loop until the GtkObject data property "action" is !=
    NULL, mates nicely with swamigui_util_quick_popup, returns value of
    "action".  Useful for complex routines that require a lot of user


### PR DESCRIPTION
This ensures that all `SwamiControl `object associated to childs `widget` inside these dialogs are properly disconnected and freed when these `childs` widget are destroyed.

See **Notes about SwamiguiControl** in `SwamiguiControl.c` for details on how a `SwamiControl` is attached to a `widget`.