### PR TITLE
Publish Windows CI binaries as artifacts

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -154,7 +154,9 @@ jobs:
         makensis $(Build.SourcesDirectory)\package\win32\swami.nsi || cd .
         rm -rf include etc docs man manifest src
         rm -f lib/*
+        mv bin/swami.exe bin/swami
         rm -f bin/*.exe
+        mv bin/swami bin/swami.exe
         rm -f bin/*.sh
       displayName: 'Copy Artifacts'
     - task: PublishBuildArtifacts@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -106,16 +106,18 @@ jobs:
         mkdir d:\deps || exit -1
         cd d:\deps || exit -1
         curl -LfsS -o gtk-bundle-dev.zip $(gtk-bundle) || exit -1
-        curl -LfsS -o libsndfile-dev.zip $(libsndfile-url) || exit -1
         curl -LfsS -o libgnomecanvas.zip $(libgnomecanvas-url) || exit -1
         curl -LfsS -o libgnomecanvas-dev.zip $(libgnomecanvas-dev-url) || exit -1
+        7z x -aos -- gtk-bundle-dev.zip > NUL || exit -1
+        7z x -aos -- libgnomecanvas.zip > NUL || exit -1
+        7z x -aos -- libgnomecanvas-dev.zip > NUL || exit -1
+        rm *.zip
+        cp -rf * $(Build.ArtifactStagingDirectory)
+        curl -LfsS -o libsndfile-dev.zip $(libsndfile-url) || exit -1
         curl -LfsS -o libart.zip $(libart-url) || exit -1
         curl -LfsS -o libart-dev.zip $(libart-dev-url) || exit -1
         curl -LfsS -o mingw.zip $(mingw-url) || exit -1
-        7z x -aos -- gtk-bundle-dev.zip > NUL || exit -1
         7z x -aos -- libsndfile-dev.zip > NUL || exit -1
-        7z x -aos -- libgnomecanvas.zip > NUL || exit -1
-        7z x -aos -- libgnomecanvas-dev.zip > NUL || exit -1
         7z x -aos -- libart.zip > NUL || exit -1
         7z x -aos -- libart-dev.zip > NUL || exit -1
         7z x -aos -- mingw.zip > NUL || exit -1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -145,6 +145,8 @@ jobs:
         del $(Build.ArtifactStagingDirectory)\bin\vcruntime*.dll
         del $(Build.ArtifactStagingDirectory)\bin\msvcp*.dll
         cd $(Build.ArtifactStagingDirectory)
+        mkdir docs/
+        cp $(Build.SourcesDirectory)\COPYING docs\distribution.txt
         makensis $(Build.SourcesDirectory)\package\win32\swami.nsi
       displayName: 'Copy Artifacts'
     - task: PublishBuildArtifacts@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -152,6 +152,10 @@ jobs:
         dir
         makensis /?
         makensis $(Build.SourcesDirectory)\package\win32\swami.nsi || cd .
+        rm -rf include etc docs man manifest src
+        rm -f lib/*
+        rm -f bin/*.exe
+        rm -f bin/*.sh
       displayName: 'Copy Artifacts'
     - task: PublishBuildArtifacts@1
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -124,8 +124,8 @@ jobs:
         mv lib\libsndfile-1.lib lib\sndfile.lib || exit -1
         mv lib\libsndfile-1.def lib\sndfile.def || exit -1
         cd mingw*\ && cp -rf * .. && cd .. && rm -rf mingw* || exit -1
-        cd $(Build.ArtifactStagingDirectory)\fluidsynth-$(platform) && cp -rf * d:\deps\ && cd .. && rm -rf $(Build.ArtifactStagingDirectory)\fluidsynth-$(platform)\ || exit -1
-        cd $(Build.ArtifactStagingDirectory)\libinstpatch-$(platform) && cp -rf * d:\deps\ && cd .. && rm -rf $(Build.ArtifactStagingDirectory)\libinstpatch-$(platform)\ || exit -1
+        cd $(Build.ArtifactStagingDirectory)\fluidsynth-$(platform) && cp -rf * d:\deps\ && cp -rf * $(Build.ArtifactStagingDirectory) && cd .. && rm -rf $(Build.ArtifactStagingDirectory)\fluidsynth-$(platform)\ || exit -1
+        cd $(Build.ArtifactStagingDirectory)\libinstpatch-$(platform) && cp -rf * d:\deps\ && cp -rf * $(Build.ArtifactStagingDirectory) && cd .. && rm -rf $(Build.ArtifactStagingDirectory)\libinstpatch-$(platform)\ || exit -1
       displayName: 'Prerequisites'
     - script: |
         @ECHO ON
@@ -144,8 +144,7 @@ jobs:
         del $(Build.ArtifactStagingDirectory)\bin\concrt*.dll
         del $(Build.ArtifactStagingDirectory)\bin\vcruntime*.dll
         del $(Build.ArtifactStagingDirectory)\bin\msvcp*.dll
-        cd $(Build.ArtifactStagingDirectory)\bin
-        cp -rf d:\deps\bin .
+        where makensis
       displayName: 'Copy Artifacts'
     - task: PublishBuildArtifacts@1
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -145,7 +145,7 @@ jobs:
         del $(Build.ArtifactStagingDirectory)\bin\vcruntime*.dll
         del $(Build.ArtifactStagingDirectory)\bin\msvcp*.dll
         cd $(Build.ArtifactStagingDirectory)
-        mkdir docs/
+        mkdir docs
         cp $(Build.SourcesDirectory)\COPYING docs\distribution.txt
         makensis $(Build.SourcesDirectory)\package\win32\swami.nsi
       displayName: 'Copy Artifacts'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -106,19 +106,19 @@ jobs:
         mkdir d:\deps || exit -1
         cd d:\deps || exit -1
         curl -LfsS -o gtk-bundle-dev.zip $(gtk-bundle) || exit -1
+        curl -LfsS -o libart.zip $(libart-url) || exit -1
         curl -LfsS -o libgnomecanvas.zip $(libgnomecanvas-url) || exit -1
-        curl -LfsS -o libgnomecanvas-dev.zip $(libgnomecanvas-dev-url) || exit -1
-        7z x -aos -- gtk-bundle-dev.zip > NUL || exit -1
         7z x -aos -- libgnomecanvas.zip > NUL || exit -1
-        7z x -aos -- libgnomecanvas-dev.zip > NUL || exit -1
+        7z x -aos -- libart.zip > NUL || exit -1
+        7z x -aos -- gtk-bundle-dev.zip > NUL || exit -1
         rm *.zip
         cp -rf * $(Build.ArtifactStagingDirectory)
+        curl -LfsS -o libgnomecanvas-dev.zip $(libgnomecanvas-dev-url) || exit -1
         curl -LfsS -o libsndfile-dev.zip $(libsndfile-url) || exit -1
-        curl -LfsS -o libart.zip $(libart-url) || exit -1
         curl -LfsS -o libart-dev.zip $(libart-dev-url) || exit -1
         curl -LfsS -o mingw.zip $(mingw-url) || exit -1
+        7z x -aos -- libgnomecanvas-dev.zip > NUL || exit -1
         7z x -aos -- libsndfile-dev.zip > NUL || exit -1
-        7z x -aos -- libart.zip > NUL || exit -1
         7z x -aos -- libart-dev.zip > NUL || exit -1
         7z x -aos -- mingw.zip > NUL || exit -1
         rm *.zip

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -136,7 +136,7 @@ jobs:
         set PATH=%PATH:C:\Program Files\Git\bin;=%
         set PATH=%PATH:C:\Program Files\Git\usr\bin;=%
         mkdir build && cd build || exit -1
-        cmake -G "MinGW Makefiles" -DCMAKE_INSTALL_PREFIX=$(Build.ArtifactStagingDirectory) -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=0 .. || exit -1
+        cmake -G "MinGW Makefiles" -DCMAKE_INSTALL_PREFIX=$(Build.ArtifactStagingDirectory) -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_VERBOSE_MAKEFILE=0 .. || exit -1
         mingw32-make.exe all || exit -1
       displayName: 'Compile swami'
     - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -147,7 +147,9 @@ jobs:
         cd $(Build.ArtifactStagingDirectory)
         mkdir docs
         cp $(Build.SourcesDirectory)\COPYING docs\distribution.txt
-        makensis $(Build.SourcesDirectory)\package\win32\swami.nsi
+        dir
+        makensis /?
+        makensis $(Build.SourcesDirectory)\package\win32\swami.nsi || cd .
       displayName: 'Copy Artifacts'
     - task: PublishBuildArtifacts@1
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -141,10 +141,11 @@ jobs:
         @ECHO ON
         cd build
         mingw32-make.exe install || exit -1
-        cp d:/deps/bin/libgnomecanvas*.dll $(Build.ArtifactStagingDirectory)
         del $(Build.ArtifactStagingDirectory)\bin\concrt*.dll
         del $(Build.ArtifactStagingDirectory)\bin\vcruntime*.dll
         del $(Build.ArtifactStagingDirectory)\bin\msvcp*.dll
+        cd $(Build.ArtifactStagingDirectory)\bin
+        cp -rf d:\deps\bin .
       displayName: 'Copy Artifacts'
     - task: PublishBuildArtifacts@1
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -144,7 +144,8 @@ jobs:
         del $(Build.ArtifactStagingDirectory)\bin\concrt*.dll
         del $(Build.ArtifactStagingDirectory)\bin\vcruntime*.dll
         del $(Build.ArtifactStagingDirectory)\bin\msvcp*.dll
-        where makensis
+        cd $(Build.ArtifactStagingDirectory)
+        makensis $(Build.SourcesDirectory)\package\win32\swami.nsi
       displayName: 'Copy Artifacts'
     - task: PublishBuildArtifacts@1
       inputs:


### PR DESCRIPTION
Make Swami binaries on Windows ready-to-use as build artifacts. I also tried to make the NSIS installer work but failed to do so.