### PR TITLE
Make "Load Files" dialog unique

### DIFF
--- a/src/swamigui/patch_funcs.c
+++ b/src/swamigui/patch_funcs.c
@@ -123,6 +123,15 @@ swamigui_load_files(GObject *parent_hint, gboolean load_samples)
     GtkWidget *dialog;
     GtkWindow *main_window;
     char *path;
+    static const char *strkey = "Load files";
+
+    /* Check if the dialog is already open and activate it.
+       This ensures that the dialog is created only one time.
+    */
+    if(swamigui_util_activate_unique_dialog(strkey, 0))
+    {
+        return;
+    }
 
     /* ++ ref main window */
     g_object_get(swamigui_root, "main-window", &main_window, NULL);
@@ -135,6 +144,9 @@ swamigui_load_files(GObject *parent_hint, gboolean load_samples)
                                          NULL);
 
     g_object_unref(main_window);	   /* -- unref main window */
+
+    /* register the dialog as unique. */
+    swamigui_util_register_unique_dialog(dialog, strkey, 0);
 
     /* enable multiple selection mode */
     gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(dialog), TRUE);

--- a/src/swamigui/util.c
+++ b/src/swamigui/util.c
@@ -56,7 +56,7 @@ static GtkWidget *log_view_widg = NULL;	/* currently active error view widg */
 typedef struct
 {
     GtkWidget *dialog;
-    gchar *strkey;
+    const gchar *strkey;
     int key2;
 } UniqueDialogKey;
 
@@ -156,7 +156,7 @@ swamigui_util_canvas_line_set(GnomeCanvasItem *item, double x1, double y1,
 
 /* looks up a unique dialog widget by its keys, returns the widget or NULL */
 GtkWidget *
-swamigui_util_lookup_unique_dialog(gchar *strkey, gint key2)
+swamigui_util_lookup_unique_dialog(const gchar *strkey, gint key2)
 {
     UniqueDialogKey *udkeyp;
     gint i;
@@ -179,7 +179,7 @@ swamigui_util_lookup_unique_dialog(gchar *strkey, gint key2)
    then activate the existing dialog and return FALSE, otherwise register the
    new dialog and return TRUE */
 gboolean
-swamigui_util_register_unique_dialog(GtkWidget *dialog, gchar *strkey,
+swamigui_util_register_unique_dialog(GtkWidget *dialog, const gchar *strkey,
                                      gint key2)
 {
     UniqueDialogKey udkey;
@@ -237,7 +237,7 @@ swamigui_util_unregister_unique_dialog(GtkWidget *dialog)
 
 /* activate (or raise) a unique dialog into view */
 gboolean
-swamigui_util_activate_unique_dialog(gchar *strkey, gint key2)
+swamigui_util_activate_unique_dialog(const gchar *strkey, gint key2)
 {
     GtkWidget *dialog;
 

--- a/src/swamigui/util.h
+++ b/src/swamigui/util.h
@@ -44,11 +44,11 @@ guint swamigui_util_unit_rgba_color_get_type(void);
 void swamigui_util_canvas_line_set(GnomeCanvasItem *item, double x1, double y1,
                                    double x2, double y2);
 GtkWidget *swamigui_util_quick_popup(gchar *msg, gchar *btn1, ...);
-GtkWidget *swamigui_util_lookup_unique_dialog(gchar *strkey, gint key2);
-gboolean swamigui_util_register_unique_dialog(GtkWidget *dialog, gchar *strkey,
+GtkWidget *swamigui_util_lookup_unique_dialog(const gchar *strkey, gint key2);
+gboolean swamigui_util_register_unique_dialog(GtkWidget *dialog, const gchar *strkey,
         gint key2);
 void swamigui_util_unregister_unique_dialog(GtkWidget *dialog);
-gboolean swamigui_util_activate_unique_dialog(gchar *strkey, gint key2);
+gboolean swamigui_util_activate_unique_dialog(const gchar *strkey, gint key2);
 
 gpointer swamigui_util_waitfor_widget_action(GtkWidget *widg);
 void swamigui_util_widget_action(GtkWidget *cbwidg, gpointer value);


### PR DESCRIPTION
This PR prevents the "Load Files" dialog to be opened multiple times.

We could think that it would be simpler to make the  dialog modal, but the style "not modal" of the dialog is useful. It allows the user to load multiples files (using button apply) and come back in the main window to close files loaded by error keeping the dialog still opened to continue loading other files.