### PR TITLE
Load file unique

### DIFF
--- a/src/libswami/SwamiLog.h
+++ b/src/libswami/SwamiLog.h
@@ -30,11 +30,12 @@
 
 typedef enum
 {
-    SWAMI_ERROR_FAIL,		/* general failure */
-    SWAMI_ERROR_INVALID,		/* invalid parameter/setting/etc */
-    SWAMI_ERROR_CANCELED,		/* an operation was canceled (SwamiLoopFinder) */
-    SWAMI_ERROR_UNSUPPORTED,	/* an unsupported feature or unhandled operation */
-    SWAMI_ERROR_IO		/* I/O related error */
+    SWAMI_ERROR_FAIL,           /* general failure */
+    SWAMI_ERROR_INVALID,        /* invalid parameter/setting/etc */
+    SWAMI_ERROR_CANCELED,       /* an operation was canceled (SwamiLoopFinder) */
+    SWAMI_ERROR_UNSUPPORTED,    /* an unsupported feature or unhandled operation */
+    SWAMI_ERROR_IO,             /* I/O related error */
+    SWAMI_ERROR_ALREADY_LOADED  /* file already loaded */
 } SwamiError;
 
 GQuark swami_error_quark(void);

--- a/src/libswami/SwamiRoot.c
+++ b/src/libswami/SwamiRoot.c
@@ -571,7 +571,7 @@ swami_root_patch_is_loaded(SwamiRoot *root, const char *filename)
     GList *list, *l; /* list in root's container */
     GObject *base;   /* IpatchBase object in root's container */
     char *path;      /* base's filename path */
-    boolean ret = FALSE; /* return value */
+    gboolean ret = FALSE; /* return value */
 
     g_return_val_if_fail(SWAMI_IS_ROOT (root), FALSE);
     g_return_val_if_fail(filename != NULL, FALSE);

--- a/src/libswami/SwamiRoot.h
+++ b/src/libswami/SwamiRoot.h
@@ -88,6 +88,7 @@ void swami_root_prepend_object(SwamiRoot *root, GObject *parent,
 void swami_root_insert_object_before(SwamiRoot *root, GObject *parent,
                                      GObject *sibling, GObject *object);
 
+gboolean swami_root_patch_is_loaded(SwamiRoot *root, const char *filename);
 gboolean swami_root_patch_load(SwamiRoot *root, const char *filename,
                                IpatchItem **item, GError **err);
 gboolean swami_root_patch_save(IpatchItem *item, const char *filename,

--- a/src/swamigui/SwamiguiMenu.c
+++ b/src/swamigui/SwamiguiMenu.c
@@ -351,8 +351,6 @@ swamigui_menu_recent_chooser_item_activated(GtkRecentChooser *chooser,
         gpointer user_data)
 {
     char *file_uri, *fname;
-    GError *err = NULL;
-    GtkWidget *msgdialog;
 
     file_uri = gtk_recent_chooser_get_current_uri(chooser);
 
@@ -370,17 +368,9 @@ swamigui_menu_recent_chooser_item_activated(GtkRecentChooser *chooser,
         return;
     }
 
-    if(!swami_root_patch_load(SWAMI_ROOT(swamigui_root), fname, NULL, &err))
-    {
-        msgdialog = gtk_message_dialog_new(NULL, 0, GTK_MESSAGE_ERROR,
-                                           GTK_BUTTONS_OK,
-                                           _("Failed to load '%s': %s"),
-                                           fname, ipatch_gerror_message(err));
-        g_clear_error(&err);
-
-        gtk_dialog_run(GTK_DIALOG(msgdialog));
-        gtk_widget_destroy(msgdialog);
-    }
+    /* loading patch file and log error on Gtk message dialog */
+    swamigui_root_patch_load(SWAMI_ROOT(swamigui_root), fname, NULL,
+                             GTK_WINDOW(swamigui_root->main_window));
 
     g_free(fname);
 }

--- a/src/swamigui/SwamiguiRoot.c
+++ b/src/swamigui/SwamiguiRoot.c
@@ -1486,9 +1486,9 @@ swamigui_root_load_prefs(SwamiguiRoot *root)
  * The log message is displayed on the console and optionally on a Gtk message
  * dialog.
  *
- * In the case of a file is really loaded with error, the message displayed
+ * In the case of a file loaded with error, the message displayed
  * is critical.
- * Because the function can ignore file already loaded, in this case
+ * Because the function can ignore a file already loaded, for this case
  * the error returned is not critical and the message displayed is an
  * information only.
  *

--- a/src/swamigui/SwamiguiRoot.c
+++ b/src/swamigui/SwamiguiRoot.c
@@ -1480,6 +1480,71 @@ swamigui_root_load_prefs(SwamiguiRoot *root)
 }
 
 /**
+ * swamigui_root_patch_load:
+ *
+ * Load an instrument patch file and displays a log error message if it fails.
+ * The log message is displayed on the console and optionally on a Gtk message
+ * dialog.
+ *
+ * In the case of a file is really loaded with error, the message displayed
+ * is critical.
+ * Because the function can ignore file already loaded, in this case
+ * the error returned is not critical and the message displayed is an
+ * information only.
+ *
+ * @root: Swami root object to load into.
+ * @filename, Name and path of file to load.
+ * @item: Location to store pointer to object that has been loaded into Swami
+ *   root object (or NULL). Remember to unref the object when done with it
+ *   (not necessary of course if NULL was passed).
+ * @parent: window parent of the Gtk message dialog created to display the log
+ *  message. If NULL no message dialog is created.
+ * @return: TRUE on success, FALSE otherwise
+ */
+gboolean swamigui_root_patch_load(SwamiRoot *root, const char *filename,
+                                  IpatchItem **item, GtkWindow *parent)
+{
+    GError *err = NULL;
+
+    g_return_val_if_fail((parent == NULL ) || GTK_IS_WINDOW(parent), FALSE);
+
+    if (!swami_root_patch_load (root, filename, item, &err))
+    {
+        /* prepare a CRITICAL log message */
+        GLogLevelFlags log_level = G_LOG_LEVEL_CRITICAL;
+        static const char *log_msg = "Failed to load file '%s': %s";
+        GtkMessageType gtk_type = GTK_MESSAGE_ERROR;
+
+        if(err->code == SWAMI_ERROR_ALREADY_LOADED)
+        {
+            /* prepare an INFO log message */
+            log_level = G_LOG_LEVEL_INFO;
+            log_msg = "Ignore file '%s': %s";
+            gtk_type = GTK_MESSAGE_INFO;
+        }
+
+        /* displaying log message on the console */
+        g_log(G_LOG_DOMAIN, log_level, log_msg, filename,
+              ipatch_gerror_message(err));
+
+        /* optionally displaying log message on a GUI dialog */
+        if(parent)
+        {
+            GtkWidget *msgdialog;
+            msgdialog = gtk_message_dialog_new(GTK_WINDOW(parent), 0, gtk_type,
+                                               GTK_BUTTONS_OK, log_msg, filename,
+                                               ipatch_gerror_message(err));
+            gtk_dialog_run(GTK_DIALOG(msgdialog));
+            gtk_widget_destroy(msgdialog);
+        }
+
+        g_clear_error(&err);
+        return FALSE;
+    }
+    return TRUE;
+}
+
+/**
  * swamigui_get_root:
  * @gobject: An object registered to a #SwamiguiRoot object
  *

--- a/src/swamigui/SwamiguiRoot.h
+++ b/src/swamigui/SwamiguiRoot.h
@@ -123,6 +123,8 @@ void swamigui_root_quit(SwamiguiRoot *root);
 SwamiguiRoot *swamigui_get_root(gpointer gobject);
 gboolean swamigui_root_save_prefs(SwamiguiRoot *root);
 gboolean swamigui_root_load_prefs(SwamiguiRoot *root);
+gboolean swamigui_root_patch_load(SwamiRoot *root, const char *filename,
+                                  IpatchItem **item, GtkWindow *parent);
 gboolean swamigui_root_is_middle_click(SwamiguiRoot *root, GdkEventButton *event);
 
 #endif

--- a/src/swamigui/SwamiguiTree.c
+++ b/src/swamigui/SwamiguiTree.c
@@ -1015,12 +1015,9 @@ swamigui_tree_cb_drag_data_received(GtkWidget *widget, GdkDragContext *context,
 
             if(fname)
             {
-                if(!swami_root_patch_load(swami_root, fname, NULL, &err))
-                {
-                    g_critical(_("Failed to load DnD file '%s': %s"), fname,
-                               ipatch_gerror_message(err));
-                    g_clear_error(&err);
-                }
+                /* loading patch file and log error on Gtk message dialog */
+                swamigui_root_patch_load(swami_root, fname, NULL,
+                                         GTK_WINDOW(swamigui_root->main_window));
 
                 g_free(fname);
             }

--- a/src/swamigui/SwamiguiTree.c
+++ b/src/swamigui/SwamiguiTree.c
@@ -1000,7 +1000,6 @@ swamigui_tree_cb_drag_data_received(GtkWidget *widget, GdkDragContext *context,
         char *uri_list;
         char **uris;
         char *fname;
-        GError *err = NULL;
         int i;
 
         uri_list = g_strndup((char *)(selection_data->data),

--- a/src/swamigui/libswamigui.def
+++ b/src/swamigui/libswamigui.def
@@ -17,6 +17,7 @@ swamigui_get_swamigui_root
 
 swamigui_root_activate
 swamigui_root_load_prefs
+swamigui_root_patch_load
 swamigui_root_new
 
 swamigui_knob_get_adjustment

--- a/src/swamigui/main.c
+++ b/src/swamigui/main.c
@@ -127,7 +127,8 @@ main(int argc, char *argv[])
                 fname = g_strdup(*sptr);
             }
 
-            if(swami_root_patch_load(SWAMI_ROOT(root), fname, NULL, &err))
+            /* loading patch file and log error on console */
+            if(swamigui_root_patch_load(SWAMI_ROOT(root), fname, NULL, NULL))
             {
                 /* Add file to recent chooser list */
                 if((file_uri = g_filename_to_uri(fname, NULL, NULL)))
@@ -141,12 +142,6 @@ main(int argc, char *argv[])
 
                     g_free(file_uri);
                 }
-            }
-            else
-            {
-                g_critical(_("Failed to open file '%s' given as program argument: %s"),
-                           fname, ipatch_gerror_message(err));
-                g_clear_error(&err);
             }
 
             g_free(fname);

--- a/src/swamigui/patch_funcs.c
+++ b/src/swamigui/patch_funcs.c
@@ -256,13 +256,13 @@ swamigui_cb_load_files_response(GtkWidget *dialog, gint response,
         {
             patch_loaded = TRUE;      // Set patch path regardless if successful
 
-            if(!swami_root_patch_load(root, fname, &patch, &err))     // ++ ref patch object
+            /* loading patch file and log error on Gtk message dialog */
+            if(!swamigui_root_patch_load(root, fname, &patch, GTK_WINDOW(dialog)))
             {
-                /* error occurred - log it */
-                g_critical(_("Failed to load file '%s': %s"), fname, ipatch_gerror_message(err));
-                g_clear_error(&err);
                 continue;
             }
+
+            /* loading is success, ++ ref on patch object */
 
             if((file_uri = g_filename_to_uri(fname, NULL, NULL)))     // ++ alloc
             {


### PR DESCRIPTION
Actually swami allows loading of the same soundfont file multiple times. 
This has the following drawbacks:

Let loading the same file (f.sf2) 2 times, we can see 2 nodes in the Patches tab tree
(1)title
(2)title

- Now the user is making change on file (1) and then a different change on file (2).
- When the user save both files (using multiple selection and the Save Files dialog), as the 2 files  have the same path (f.sf2),  saving the second file (2) overwrite on the file system what was previously saved for the first file (1).

Not only the change made on file (1) are overwritten on the file system, but what is displayed in widget for this file (1) does not correspond to what was recorded on the file system. The user get quickly confused by an incoherent result.

To fix these issues, this PR avoid loading the same file multiple times. When loading a file, the loading function checks if the file is already loaded and if it is the case an information message is displayed and loading is skipped.
