### PR TITLE
This PR Fixes and completes "Save file as" dialog behaviour

### DIFF
--- a/src/libswami/SwamiRoot.c
+++ b/src/libswami/SwamiRoot.c
@@ -564,6 +564,9 @@ swami_root_insert_object_before(SwamiRoot *root, GObject *parent,
  *
  * The function look in the root's container in which file are
  * loaded by swami_root_patch_load().
+ *
+ * Note: Swami considers file name "case insensitive" regardless of the host OS.
+ * That means that f.sf2 is considered the same file as F.sf2.
  */
 gboolean
 swami_root_patch_is_loaded(SwamiRoot *root, const char *filename)
@@ -585,7 +588,8 @@ swami_root_patch_is_loaded(SwamiRoot *root, const char *filename)
     {
         base = (GObject *)l->data;  /* IpatchBase object */
         g_object_get(base, "file-name", &path, NULL);   /* ++ alloc path */
-        ret = path && (strcmp(path, filename) == 0);
+        /* note that the comparison is "case insensitive" */
+        ret = path && (g_ascii_strcasecmp(path, filename) == 0);
         g_free(path);  /* free path */
         if(ret)
         {

--- a/src/libswami/libswami.def
+++ b/src/libswami/libswami.def
@@ -332,6 +332,7 @@ swami_param_type_transformable
 swami_get_control_prop
 swami_container_get_type
 swami_object_set_origin
+swami_root_patch_is_loaded
 swami_root_patch_load
 swami_control_prop_connect_to_control
 ;swami_patch_add_control

--- a/src/swamigui/SwamiguiMultiSave.c
+++ b/src/swamigui/SwamiguiMultiSave.c
@@ -44,7 +44,6 @@ enum
 };
 
 static void swamigui_multi_save_finalize(GObject *object);
-static void browse_clicked(GtkButton *button, gpointer user_data);
 static GtkFileChooserConfirmation
 warning_overwrite_callback(GtkFileChooser *chooser, gpointer data);
 static void save_toggled(GtkCellRendererToggle *cell, char *path_str,
@@ -101,7 +100,7 @@ swamigui_multi_save_init(SwamiguiMultiSave *multi)
     image = gtk_image_new_from_stock(GTK_STOCK_OPEN, GTK_ICON_SIZE_BUTTON);
     gtk_button_set_image(GTK_BUTTON(btn), image);
     gtk_box_pack_end(GTK_BOX(hbox), btn, FALSE, FALSE, 0);
-    g_signal_connect(btn, "clicked", G_CALLBACK(browse_clicked), multi);
+    g_signal_connect(btn, "clicked", G_CALLBACK (swamigui_save_as_browser), multi);
 
     gtk_widget_show_all(hbox);
 
@@ -202,8 +201,7 @@ swamigui_multi_save_finalize(GObject *object)
 }
 
 /* browse button clicked callback */
-static void
-browse_clicked(GtkButton *button, gpointer user_data)
+void swamigui_save_as_browser(GtkButton *button, gpointer user_data)
 {
     SwamiguiMultiSave *multi = SWAMIGUI_MULTI_SAVE(user_data);
     GtkWidget *filesel;

--- a/src/swamigui/SwamiguiMultiSave.c
+++ b/src/swamigui/SwamiguiMultiSave.c
@@ -549,6 +549,13 @@ swamigui_multi_save_new(char *title, char *message, guint flags)
         gtk_button_set_label(GTK_BUTTON(multi->accept_btn), GTK_STOCK_CLOSE);
     }
 
+    /* here we are in "Save files" dialog. To retain user attention and disable
+       access to menu in other window, the dialog must be modal */
+    gtk_window_set_modal(GTK_WINDOW(multi), TRUE);
+
+    /* the dialog is centered on the main window */
+    gtk_window_set_transient_for(GTK_WINDOW(multi), GTK_WINDOW(swamigui_root->main_window));
+
     return (GTK_WIDGET(multi));
 }
 

--- a/src/swamigui/SwamiguiMultiSave.c
+++ b/src/swamigui/SwamiguiMultiSave.c
@@ -323,6 +323,9 @@ void swamigui_save_as_browser(GtkButton *button, gpointer user_data)
  *
  *  (3) new file name is not in use by swami, the user is requested to
  *      confirm that the file could be overwritten.
+ *
+ * Note: Swami consider file name "case insensitive" regardless of the host OS.
+ * That means that f.sf2 should be considered the same file as F.sf2.
  */
 static GtkFileChooserConfirmation
 warning_overwrite_callback(GtkFileChooser *chooser, gpointer data)
@@ -341,7 +344,8 @@ warning_overwrite_callback(GtkFileChooser *chooser, gpointer data)
     new_fname = gtk_file_chooser_get_filename(chooser); /* ++ alloc */
 
     /* check if new_fname is identical to initial file name */
-    if(init_fname && strcmp(init_fname, new_fname) == 0)
+    /* note that the comparison is "case insensitive" */
+    if(init_fname && g_ascii_strcasecmp(init_fname, new_fname) == 0)
     {
         g_free(new_fname);
         return GTK_FILE_CHOOSER_CONFIRMATION_ACCEPT_FILENAME;

--- a/src/swamigui/SwamiguiMultiSave.h
+++ b/src/swamigui/SwamiguiMultiSave.h
@@ -74,6 +74,7 @@ typedef enum
 
 GType swamigui_multi_save_get_type(void);
 GtkWidget *swamigui_multi_save_new(char *title, char *message, guint flags);
+void swamigui_save_as_browser(GtkButton *button, gpointer user_data);
 void swamigui_multi_save_set_selection(SwamiguiMultiSave *multi,
                                        IpatchList *selection);
 

--- a/src/swamigui/patch_funcs.c
+++ b/src/swamigui/patch_funcs.c
@@ -626,7 +626,20 @@ swamigui_save_files(IpatchList *item_list, gboolean saveas)
     dialog = swamigui_multi_save_new(_("Save files"),
                                      _("Select files to save"), 0);
     swamigui_multi_save_set_selection(SWAMIGUI_MULTI_SAVE(dialog), item_list);
-    gtk_widget_show(dialog);
+
+    /* if "save as" is requested and the selection is simple opens the
+       "File save as" dialog directly otherwise the "Save files dialog" is show.
+    */
+    if(saveas && (item_list && item_list->items  && !item_list->items->next))
+    {
+        /* opens "file save as" dialog */
+        swamigui_save_as_browser(NULL, SWAMIGUI_MULTI_SAVE(dialog));
+        gtk_widget_destroy(dialog);
+    }
+    else
+    {
+        gtk_widget_show(dialog); /* show "Save files" dialog */
+    }
 }
 
 /**


### PR DESCRIPTION
Actually the dialog **"Save files"** has a  **"Save file as"** dialog (via "browse" button). Both have the following drawbacks:
1) Both are not modal  allowing to open multiples instances of these dialog which is a confusing behaviour.
2) Using `"save file as"` dialog should allow to change the path (cur_name) of current row selected in "Save files" list (see **note1**):
2.1) This works if the new file name does not exist on the file system, we notice:
2.1.1) The new file name  is updated  in the path column of "Save Files" dialog and,
2.1.2) the new file is written on the file system.
2.2) If the new file name corresponds to an existing file, we notice a confusing behaviour:
2.2.1) The new file name is updated  in the path column of "Save Files" dialog and,
2.2.2) the new file is NOT written on the file system, but the previous file (cur_name) is updated on the file system which is incoherent with what is displayed in 2.2.1.
**note1**: The file is written in "Save files" dialog (not in "Save file as" dialog).

This PR fixes these issues (and adds enhancements : 2.2.2, 2.2.3, 3.1 below) :
1) Both dialog ("Save files" and "Save file as") are modal.
2) "Save file as" dialog has now the expected behaviour (see **note2**):
2.1) If the new file name does not exist on the file system. Same as before, the new file is written.
2.2) If the new file name corresponds to an existing file:
2.2.1) if new file name is the same as current name (cur_name), the file is written.
2.2.2) otherwise if new file name is a file already loaded in swami, the operation is not allowed to prevent overwriting a file in use by swami.
2.2.3) otherwise a dialog is opened to request confirmation from the user to overwrite this existing file.
**note2**: The file is written here in "Save file as" dialog. So it is not necessary to duplicate saving in "Save files" dialog.
3) When multiples soundfonts files have been loaded in the **patches** tree:
3.1) if the user selects only one file in the tree, the "Save As" popup menu (right click) opens directly the "Save file as" dialog, otherwise (the user has selected multiples files) the "Save files" dialog is opened.
