### PR TITLE
GObject stopped accepting periods (`.`) in property names.

### DIFF
--- a/src/plugins/fluidsynth.c
+++ b/src/plugins/fluidsynth.c
@@ -754,6 +754,9 @@ settings_foreach_func(void *data, const char *name, int type)
     int optcount = 0;
     char *optname;
 
+    /* GObject property names don't allow '.' */
+    char *gobj_name = g_strdelimit(g_strdup(name), ".", '-');
+
     /* check if this property is on the string boolean list */
     for(sp = settings_str_bool; *sp; sp++)
         if(type == FLUID_STR_TYPE && strcmp(name, *sp) == 0)
@@ -764,7 +767,7 @@ settings_foreach_func(void *data, const char *name, int type)
     if(*sp)	/* string boolean value? */
     {
         bdef = fluid_settings_str_equal(bag->settings, name, "yes");
-        spec = g_param_spec_boolean(name, name, name, bdef, G_PARAM_READWRITE);
+        spec = g_param_spec_boolean(gobj_name, name, name, bdef, G_PARAM_READWRITE);
 
         /* set PROP_STRING_BOOL property flag */
         dynamic_prop_flags[last_property_id - FIRST_DYNAMIC_PROP] |= PROP_STRING_BOOL;
@@ -776,7 +779,7 @@ settings_foreach_func(void *data, const char *name, int type)
         case FLUID_NUM_TYPE:
             fluid_settings_getnum_range(bag->settings, name, &dmin, &dmax);
             fluid_settings_getnum_default(bag->settings, name, &ddef);
-            spec = g_param_spec_double(name, name, name, dmin, dmax, ddef,
+            spec = g_param_spec_double(gobj_name, name, name, dmin, dmax, ddef,
                                        G_PARAM_READWRITE);
             break;
 
@@ -787,18 +790,18 @@ settings_foreach_func(void *data, const char *name, int type)
 
             if((hint & FLUID_HINT_TOGGLED) != 0)	/* boolean parameter? */
             {
-                spec = g_param_spec_boolean(name, name, name, idef != 0, G_PARAM_READWRITE);
+                spec = g_param_spec_boolean(gobj_name, name, name, idef != 0, G_PARAM_READWRITE);
             }
             else
             {
-                spec = g_param_spec_int(name, name, name, imin, imax, idef, G_PARAM_READWRITE);
+                spec = g_param_spec_int(gobj_name, name, name, imin, imax, idef, G_PARAM_READWRITE);
             }
 
             break;
 
         case FLUID_STR_TYPE:
             fluid_settings_getstr_default(bag->settings, name, &defstr);
-            spec = g_param_spec_string(name, name, name, defstr, G_PARAM_READWRITE);
+            spec = g_param_spec_string(gobj_name, name, name, defstr, G_PARAM_READWRITE);
 
             /* count options for this string parameter (if any) */
             fluid_settings_foreach_option(bag->settings, name, &optcount,
@@ -839,7 +842,7 @@ settings_foreach_func(void *data, const char *name, int type)
     /* install an options parameter if there are any string options */
     if(options)
     {
-        optname = g_strconcat(name, "-options", NULL);	/* ++ alloc */
+        optname = g_strconcat(gobj_name, "-options", NULL);	/* ++ alloc */
         spec = g_param_spec_boxed(optname, optname, optname, G_TYPE_STRV,
                                   G_PARAM_READABLE);
 
@@ -855,6 +858,8 @@ settings_foreach_func(void *data, const char *name, int type)
 
         last_property_id++;	/* advance the last dynamic property ID */
     }
+
+    g_free(gobj_name);
 }
 
 /* function to iterate over FluidSynth string options for string parameters

--- a/src/plugins/fluidsynth_gui.c
+++ b/src/plugins/fluidsynth_gui.c
@@ -136,7 +136,7 @@ fluid_synth_pref_handler(void)
                                        "text", 0,
                                        NULL);
 
-        g_object_get(swamigui_root->wavetbl, "audio.driver-options", &options, NULL);	/* ++ alloc */
+        g_object_get(swamigui_root->wavetbl, "audio-driver-options", &options, NULL);	/* ++ alloc */
 
         for(optionp = options; *optionp; optionp++)
         {
@@ -149,9 +149,9 @@ fluid_synth_pref_handler(void)
         g_signal_connect(widg, "changed",
                          G_CALLBACK(fluid_synth_gui_audio_driver_changed), fluid_widg);
 
-        /* Connect the audio combo box to the "audio.driver" property */
+        /* Connect the audio combo box to the "audio.driver" FluidSynth setting */
         swamigui_control_prop_connect_widget(G_OBJECT(swamigui_root->wavetbl),
-                                             "audio.driver", G_OBJECT(widg));
+                                             "audio-driver", G_OBJECT(widg));
 
         /* Initialize MIDI driver list */
         widg = swamigui_util_glade_lookup(fluid_widg, "ComboMidiDriver");
@@ -166,7 +166,7 @@ fluid_synth_pref_handler(void)
                                        "text", 0,
                                        NULL);
 
-        g_object_get(swamigui_root->wavetbl, "midi.driver-options", &options, NULL);	/* ++ alloc */
+        g_object_get(swamigui_root->wavetbl, "midi-driver-options", &options, NULL);	/* ++ alloc */
 
         for(optionp = options; *optionp; optionp++)
         {
@@ -179,9 +179,9 @@ fluid_synth_pref_handler(void)
         g_signal_connect(widg, "changed",
                          G_CALLBACK(fluid_synth_gui_midi_driver_changed), fluid_widg);
 
-        /* Connect the MIDI combo box to the "midi.driver" property */
+        /* Connect the MIDI combo box to the "midi.driver" FluidSynth setting */
         swamigui_control_prop_connect_widget(G_OBJECT(swamigui_root->wavetbl),
-                                             "midi.driver", G_OBJECT(widg));
+                                             "midi-driver", G_OBJECT(widg));
 
         /* Connect widgets to FluidSynth properties */
         swamigui_control_glade_prop_connect(fluid_widg, G_OBJECT(swamigui_root->wavetbl));
@@ -364,7 +364,7 @@ fluid_synth_gui_control_init(FluidSynthGuiControl *fsctrl)
     }
 
     /* ++Ref  */
-    propctrl = swami_get_control_prop_by_name(G_OBJECT(wavetbl), "synth.reverb.active");
+    propctrl = swami_get_control_prop_by_name(G_OBJECT(wavetbl), "synth-reverb-active");
     widg = swamigui_util_glade_lookup(fsctrl->ctrl_widg, "BtnReverb");
     /* widget control is owned by the widget (it will be freed when the widget
        will be destroyed) */
@@ -376,7 +376,7 @@ fluid_synth_gui_control_init(FluidSynthGuiControl *fsctrl)
     fsctrl->ctrl_list = g_slist_append(fsctrl->ctrl_list, propctrl);
 
     /* ++Ref  */
-    propctrl = swami_get_control_prop_by_name(G_OBJECT(wavetbl), "synth.chorus.active");
+    propctrl = swami_get_control_prop_by_name(G_OBJECT(wavetbl), "synth-chorus-active");
     widg = swamigui_util_glade_lookup(fsctrl->ctrl_widg, "BtnChorus");
     /* widget control is owned by the widget (it will be freed when the widget
        will be destroyed) */


### PR DESCRIPTION
The `.` in GObject property names was causing a crash when I tried to open Preferences. This fixes it, at least for me.

This bug also causes `~/.config/swami/preferences.xml` to lose any of the FluidSynth settings with `.` in the name.

I don't have a copy of `preferences.xml` from before this bug, so I don't know if this preserves old FluidSynth settings in `preferences.xml` people might have.

The issue started after I upgraded from Ubuntu 18.04 to 20.04.1, with GLib 2.64.3-1~ubuntu20.04.1. Presumably GObject changed the rules with the new version.

Not sure where the [GObject manual](https://developer.gnome.org/gobject/stable/) says that `.` isn't a valid part of a property name. Seems like that ought to be in there somewhere.

I probably missed a spot somewhere, but whatcha gonna do.