### PR TITLE
Ensure correct gobject property name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,7 @@ endif ( enable-source-build )
 find_package ( PkgConfig REQUIRED )
 
 # Mandatory library libinstpatch
-pkg_check_modules ( LIBINSTPATCH REQUIRED libinstpatch-1.0>=1.1.6 )
+pkg_check_modules ( LIBINSTPATCH REQUIRED libinstpatch-1.0>=1.1.5 )
 
 # Mandatory libraries: GTK+ and libgnomecanvas
 pkg_check_modules ( GUI REQUIRED gtk+-2.0>=2.12 libgnomecanvas-2.0>=2.0 )

--- a/src/plugins/fluidsynth.c
+++ b/src/plugins/fluidsynth.c
@@ -669,7 +669,7 @@ wavetbl_fluidsynth_class_init(WavetblFluidSynthClass *klass)
     g_object_class_install_property(obj_class, WTBL_PROP_CHORUS_COUNT,
                                     g_param_spec_int("chorus-count", _("Chorus count"),
                                             _("Number of chorus delay lines"),
-                                            1, 99, chorus_presets[0].count,
+                                            0, 99, chorus_presets[0].count,
                                             G_PARAM_READWRITE));
     g_object_class_install_property(obj_class, WTBL_PROP_CHORUS_LEVEL,
                                     g_param_spec_double("chorus-level", _("Chorus level"),
@@ -679,12 +679,12 @@ wavetbl_fluidsynth_class_init(WavetblFluidSynthClass *klass)
     g_object_class_install_property(obj_class, WTBL_PROP_CHORUS_FREQ,
                                     g_param_spec_double("chorus-freq", _("Chorus freq"),
                                             _("Chorus modulation frequency (Hz)"),
-                                            0.3, 5.0, chorus_presets[0].freq,
+                                            0.1, 5.0, chorus_presets[0].freq,
                                             G_PARAM_READWRITE));
     g_object_class_install_property(obj_class, WTBL_PROP_CHORUS_DEPTH,
                                     g_param_spec_double("chorus-depth", _("Chorus depth"),
                                             _("Chorus depth"),
-                                            0.0, 20.0, chorus_presets[0].depth,
+                                            0.0, 46.0, chorus_presets[0].depth,
                                             G_PARAM_READWRITE));
     g_object_class_install_property(obj_class, WTBL_PROP_CHORUS_WAVEFORM,
                                     g_param_spec_enum("chorus-waveform", _("Chorus waveform"),

--- a/src/plugins/fluidsynth_gui.c
+++ b/src/plugins/fluidsynth_gui.c
@@ -149,7 +149,7 @@ fluid_synth_pref_handler(void)
         g_signal_connect(widg, "changed",
                          G_CALLBACK(fluid_synth_gui_audio_driver_changed), fluid_widg);
 
-        /* Connect the audio combo box to the "audio.driver" FluidSynth setting */
+        /* Connect the audio combo box to the "audio-driver" wavetbl property */
         swamigui_control_prop_connect_widget(G_OBJECT(swamigui_root->wavetbl),
                                              "audio-driver", G_OBJECT(widg));
 
@@ -179,7 +179,7 @@ fluid_synth_pref_handler(void)
         g_signal_connect(widg, "changed",
                          G_CALLBACK(fluid_synth_gui_midi_driver_changed), fluid_widg);
 
-        /* Connect the MIDI combo box to the "midi.driver" FluidSynth setting */
+        /* Connect the MIDI combo box to the "midi-driver" wavetbl property */
         swamigui_control_prop_connect_widget(G_OBJECT(swamigui_root->wavetbl),
                                              "midi-driver", G_OBJECT(widg));
 

--- a/src/plugins/fluidsynth_gui.c
+++ b/src/plugins/fluidsynth_gui.c
@@ -136,7 +136,7 @@ fluid_synth_pref_handler(void)
                                        "text", 0,
                                        NULL);
 
-        g_object_get(swamigui_root->wavetbl, "audio.driver-options", &options, NULL);	/* ++ alloc */
+        g_object_get(swamigui_root->wavetbl, "audio-driver-options", &options, NULL);	/* ++ alloc */
 
         for(optionp = options; *optionp; optionp++)
         {
@@ -151,7 +151,7 @@ fluid_synth_pref_handler(void)
 
         /* Connect the audio combo box to the "audio.driver" property */
         swamigui_control_prop_connect_widget(G_OBJECT(swamigui_root->wavetbl),
-                                             "audio.driver", G_OBJECT(widg));
+                                             "audio-driver", G_OBJECT(widg));
 
         /* Initialize MIDI driver list */
         widg = swamigui_util_glade_lookup(fluid_widg, "ComboMidiDriver");
@@ -166,7 +166,7 @@ fluid_synth_pref_handler(void)
                                        "text", 0,
                                        NULL);
 
-        g_object_get(swamigui_root->wavetbl, "midi.driver-options", &options, NULL);	/* ++ alloc */
+        g_object_get(swamigui_root->wavetbl, "midi-driver-options", &options, NULL);	/* ++ alloc */
 
         for(optionp = options; *optionp; optionp++)
         {

--- a/src/swamigui/swami-2.ui
+++ b/src/swamigui/swami-2.ui
@@ -778,68 +778,6 @@ BALATON Zoltan &lt;balaton@users.sourceforge.net&gt; (Spectralis support, Mac OS
         <property name="y_options"/>
       </packing>
     </child>
-    <child>
-      <object class="GtkSpinButton" id="PROP::audio-input-channels">
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="invisible_char">•</property>
-        <property name="primary_icon_activatable">False</property>
-        <property name="secondary_icon_activatable">False</property>
-        <property name="primary_icon_sensitive">True</property>
-        <property name="secondary_icon_sensitive">True</property>
-        <property name="adjustment">adjustment3</property>
-      </object>
-      <packing>
-        <property name="left_attach">1</property>
-        <property name="right_attach">2</property>
-        <property name="top_attach">1</property>
-        <property name="bottom_attach">2</property>
-        <property name="y_options"/>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkLabel" id="label49">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="xalign">0</property>
-        <property name="label" translatable="yes">Input channels</property>
-      </object>
-      <packing>
-        <property name="top_attach">1</property>
-        <property name="bottom_attach">2</property>
-        <property name="x_options">GTK_FILL</property>
-        <property name="y_options"/>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkSpinButton" id="PROP::audio-output-channels">
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="invisible_char">•</property>
-        <property name="primary_icon_activatable">False</property>
-        <property name="secondary_icon_activatable">False</property>
-        <property name="primary_icon_sensitive">True</property>
-        <property name="secondary_icon_sensitive">True</property>
-        <property name="adjustment">adjustment4</property>
-      </object>
-      <packing>
-        <property name="left_attach">1</property>
-        <property name="right_attach">2</property>
-        <property name="y_options"/>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkLabel" id="label39">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="xalign">0</property>
-        <property name="label" translatable="yes">Output channels</property>
-      </object>
-      <packing>
-        <property name="x_options">GTK_FILL</property>
-        <property name="y_options"/>
-      </packing>
-    </child>
   </object>
   <object class="GtkTable" id="FluidSynth-Audio:oss">
     <property name="visible">True</property>


### PR DESCRIPTION
This addresses issue https://github.com/swami/swami/issues/61.

When registering gobject's property from fluidsynth settings, we must ensure that the property name doesn't contain a dot.
Dot character '.' are explicitly replaced by '-'.